### PR TITLE
Add citation strings in APA format and DOIs

### DIFF
--- a/data/names/E/Eulophia.csv
+++ b/data/names/E/Eulophia.csv
@@ -6,87 +6,48 @@ e38d6490-8fd1-11eb-924d-9cd76263cbd0,genus,Eulophia,,,R.Br.,,1821,,"Bot. Reg. 7:
 87bc54fe-8fcd-11eb-924d-9cd76263cbd0,species,aculeata,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634393-1,wfo-0000959630,5311564,,
 87bc8b0e-8fcd-11eb-924d-9cd76263cbd0,subspecies,huttonii,Eulophia,aculeata,"(Rolfe) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 183 1965",,,,87e1699c-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959632,5311566,,
 87bca648-8fcd-11eb-924d-9cd76263cbd0,species,acuminata,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 39 1912",,,,,,634394-1,wfo-0000959633,5312014,,
-87bcc646-8fcd-11eb-924d-9cd76263cbd0,species,acutilabra,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
-
-
-",Q55778720,DOI:10.2307/4107556,,,634395-1,wfo-0000959634,5311420,,
+87bcc646-8fcd-11eb-924d-9cd76263cbd0,species,acutilabra,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556",Q55778720,DOI:10.2307/4107556,,,634395-1,wfo-0000959634,5311420,,
 87bce3ec-8fcd-11eb-924d-9cd76263cbd0,species,adenoglossa,Eulophia,,"(Lindl.) Rchb.f.",,1878,,"Otia Bot. Hamburg. 66 1878",,,,,,634396-1,wfo-0000959635,5311293,,
 87bcfed6-8fcd-11eb-924d-9cd76263cbd0,species,aemula,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 26 1895",,,,,,634397-1,wfo-0000959636,5311394,,
-87bd1b3c-8fcd-11eb-924d-9cd76263cbd0,species,aequalis,Eulophia,,"(Lindl.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 182 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db44b5f0-8fcb-11eb-924d-9cd76263cbd0,,634398-1,wfo-0000959637,5312168,,
+87bd1b3c-8fcd-11eb-924d-9cd76263cbd0,species,aequalis,Eulophia,,"(Lindl.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 182 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db44b5f0-8fcb-11eb-924d-9cd76263cbd0,,634398-1,wfo-0000959637,5312168,,
 87bd5af2-8fcd-11eb-924d-9cd76263cbd0,species,agrostophylla,Eulophia,,F.M.Bailey,,1895,,"Proc. Roy. Soc. Queensland 11(1): 16 1895",,,,,,634399-1,wfo-0000959639,5312087,,
 87bd773a-8fcd-11eb-924d-9cd76263cbd0,species,albiflora,Eulophia,,"Edgew. ex Lindl.",,1858,,"J. Proc. Linn. Soc., Bot. 3: 24 1858",,,,,,634400-1,wfo-0000959640,5311470,,
 af203598-8fd1-11eb-924d-9cd76263cbd0,species,albo-brunnea,Eulophia,,"Kraenzl. ex Engl.",,1906,,"Sitz. Preuss. Akad. Wiss. 739 1906",,,,,,634401-1,wfo-0001222933,8080320,,
 87bd9166-8fcd-11eb-924d-9cd76263cbd0,species,albobrunnea,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 69 1902",,,,,,634402-1,wfo-0000959641,5311991,,
-87bdadcc-8fcd-11eb-924d-9cd76263cbd0,species,alexandri,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db44f240-8fcb-11eb-924d-9cd76263cbd0,,634403-1,wfo-0000959642,5311658,,
+87bdadcc-8fcd-11eb-924d-9cd76263cbd0,species,alexandri,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db44f240-8fcb-11eb-924d-9cd76263cbd0,,634403-1,wfo-0000959642,5311658,,
 87bdca82-8fcd-11eb-924d-9cd76263cbd0,species,alismatophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 543 1885",,,,,,634404-1,wfo-0000959643,5323761,,
-87bde4d6-8fcd-11eb-924d-9cd76263cbd0,species,aliwalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248
-
-
-",Q55782215,DOI:10.2307/4113248,,,634405-1,wfo-0000959644,5311414,,
+87bde4d6-8fcd-11eb-924d-9cd76263cbd0,species,aliwalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248",Q55782215,DOI:10.2307/4113248,,,634405-1,wfo-0000959644,5311414,,
 87bdff20-8fcd-11eb-924d-9cd76263cbd0,species,allisonii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 39 1912",,,,,,634406-1,wfo-0000959645,5312013,,
 87be1a78-8fcd-11eb-924d-9cd76263cbd0,species,aloifolia,Eulophia,,"Welw. ex Rchb.f.",,1867,,"Flora 50: 104 1867",,,,,,634407-1,wfo-0000959646,5311831,,
 87be3792-8fcd-11eb-924d-9cd76263cbd0,species,alta,Eulophia,,"(L.) Fawc. & Rendle",,1910,,"Fl. Jamaica 1: 112 1910",,,,,,99292-2,wfo-0000959647,5311790,,
 87be53a8-8fcd-11eb-924d-9cd76263cbd0,variety,alba,Eulophia,alta,L.C.Menezes,,1998,,"Bol. CAOB 33: 70 1998",,,,,,320902-2,wfo-0000959648,5311802,,
-54574ea8-8fcc-11eb-924d-9cd76263cbd0,form,flavescens,Eulophia,alta,"(Schltr.) F.Barros",,2004,,"Orchid Memories 20 2004","Seidenfaden, G., Manilal, K. S., Kumar, C. S., & Taxonomy, I. A. for A. (2004). Orchid memories (p. 265).
-
-
-",Q16613943,,,,77062297-1,wfo-0000416183,5311808,,
+54574ea8-8fcc-11eb-924d-9cd76263cbd0,form,flavescens,Eulophia,alta,"(Schltr.) F.Barros",,2004,,"Orchid Memories 20 2004","Seidenfaden, G., Manilal, K. S., Kumar, C. S., & Taxonomy, I. A. for A. (2004). Orchid memories (p. 265).",Q16613943,,,,77062297-1,wfo-0000416183,5311808,,
 35a71604-8fcd-11eb-924d-9cd76263cbd0,variety,pachystelidia,Eulophia,alta,"(Rchb.f.) G.A.Romero",,2005,,"Vanishing Beauty, Native Costa Rican Orchids 1: 318 2005",,,,,,77069774-1,wfo-0000805776,,,
 87be8c42-8fcd-11eb-924d-9cd76263cbd0,form,pallida,Eulophia,alta,P.M.Br.,,1995,,"N. Amer. Native Orchid J. 1: 132 1995",,,,,,985132-1,wfo-0000959650,5311793,,
 87bea682-8fcd-11eb-924d-9cd76263cbd0,form,pelchatii,Eulophia,alta,P.M.Br.,,1998,,"N. Amer. Native Orchid J. 4: 46 1998",,,,,,315481-2,wfo-0000959651,5311811,,
-87bec00e-8fcd-11eb-924d-9cd76263cbd0,species,amajubae,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634409-1,wfo-0000959652,5311396,,
+87bec00e-8fcd-11eb-924d-9cd76263cbd0,species,amajubae,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634409-1,wfo-0000959652,5311396,,
 87bedc4c-8fcd-11eb-924d-9cd76263cbd0,species,ambaxiana,Eulophia,,J.J.Sm.,,1909,,"Nova Guinea 8: 26 1909",,,,,,634410-1,wfo-0000959653,5311757,,
-87bef786-8fcd-11eb-924d-9cd76263cbd0,species,amblyosepala,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,c4494e18-8fcd-11eb-924d-9cd76263cbd0,,634411-1,wfo-0000959654,5311590,,
+87bef786-8fcd-11eb-924d-9cd76263cbd0,species,amblyosepala,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,c4494e18-8fcd-11eb-924d-9cd76263cbd0,,634411-1,wfo-0000959654,5311590,,
 87bf303e-8fcd-11eb-924d-9cd76263cbd0,species,amblypetala,Eulophia,,Kraenzl.,,1923,,"Vierteljahrsschr. Naturf. Ges. Zürich 68: 420 1923",,,,,,634412-1,wfo-0000959655,5311911,,
 87bfb590-8fcd-11eb-924d-9cd76263cbd0,species,ambongensis,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 169 1913",,,,,,634413-1,wfo-0000959656,5323745,,
 87c00040-8fcd-11eb-924d-9cd76263cbd0,species,ambositrana,Eulophia,,Schltr.,,1916,,"Beih. Bot. Centralbl. 34(2): 331 1916",,,,,,634414-1,wfo-0000959657,5311875,,
-87c01c60-8fcd-11eb-924d-9cd76263cbd0,species,ambrensis,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634415-1,wfo-0000959658,5323763,,
-87c039b6-8fcd-11eb-924d-9cd76263cbd0,species,amplipetala,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634416-1,wfo-0000959659,5312111,,
+87c01c60-8fcd-11eb-924d-9cd76263cbd0,species,ambrensis,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634415-1,wfo-0000959658,5323763,,
+87c039b6-8fcd-11eb-924d-9cd76263cbd0,species,amplipetala,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634416-1,wfo-0000959659,5312111,,
 87c07520-8fcd-11eb-924d-9cd76263cbd0,species,andamanensis,Eulophia,,Rchb.f.,,1872,,"Flora 55: 276 1872",,,,,,634417-1,wfo-0000959661,5311302,,
 87c08f2e-8fcd-11eb-924d-9cd76263cbd0,species,andersonii,Eulophia,,"(Rolfe) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,,,634418-1,wfo-0000959662,5311348,,
-87c0aaf4-8fcd-11eb-924d-9cd76263cbd0,species,angolensis,Eulophia,,"(Rchb.f.) Summerh.",,1958,,"Kew Bull. 13: 76 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634419-1,wfo-0000959663,5312088,,
+87c0aaf4-8fcd-11eb-924d-9cd76263cbd0,species,angolensis,Eulophia,,"(Rchb.f.) Summerh.",,1958,,"Kew Bull. 13: 76 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634419-1,wfo-0000959663,5312088,,
 87c0cab6-8fcd-11eb-924d-9cd76263cbd0,variety,mweruensis,Eulophia,angolensis,"(P.J.Cribb) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 645 1992",,,,87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,,967481-1,wfo-0000959664,5311532,,
 d239eef2-8fd1-11eb-924d-9cd76263cbd0,species,angornensis,Eulophia,,"(Rchb.f.) Hermans",,2007,,"Orchids Madagasc. (ed. 2) 178 2007",,,,8b87a16a-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0001282934,7511634,,
 87c160ca-8fcd-11eb-924d-9cd76263cbd0,species,angornensis,Eulophia,,"(Rchb.f.) P.J.Cribb",,1998,,"Lindleyana 13: 174 1998",,,,8b87a16a-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959669,5311896,,
 87c0e80c-8fcd-11eb-924d-9cd76263cbd0,species,angustiflora,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 396 1909",,,,,,634420-1,wfo-0000959665,5311430,,
 87c10468-8fcd-11eb-924d-9cd76263cbd0,species,angustilabellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 109 1919",,,,,,634421-1,wfo-0000959666,5311900,,
-87c121b4-8fcd-11eb-924d-9cd76263cbd0,species,angustilabris,Eulophia,,Seidenf.,,1985,,"Nordic J. Bot. 5: 166 1985","Seidenfaden, G. (2008). Contributions to the orchid flora of Thailand XI. Nordic Journal of Botany, 5(2), 157–167. https://doi.org/10.1111/j.1756-1051.1985.tb02085.x
-
-
-",Q55761278,DOI:10.1111/j.1756-1051.1985.tb02085.x,,,906057-1,wfo-0000959667,5311981,,
-87c1443c-8fcd-11eb-924d-9cd76263cbd0,species,anisotepala,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555
-
-
-",Q55778719,DOI:10.2307/4107555,,,634422-1,wfo-0000959668,5312037,,
+87c121b4-8fcd-11eb-924d-9cd76263cbd0,species,angustilabris,Eulophia,,Seidenf.,,1985,,"Nordic J. Bot. 5: 166 1985","Seidenfaden, G. (2008). Contributions to the orchid flora of Thailand XI. Nordic Journal of Botany, 5(2), 157–167. https://doi.org/10.1111/j.1756-1051.1985.tb02085.x",Q55761278,DOI:10.1111/j.1756-1051.1985.tb02085.x,,,906057-1,wfo-0000959667,5311981,,
+87c1443c-8fcd-11eb-924d-9cd76263cbd0,species,anisotepala,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555",Q55778719,DOI:10.2307/4107555,,,634422-1,wfo-0000959668,5312037,,
 bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.J.Cribb",,1999,,"Orchids Madagasc. 4 1999",,,,af3ae618-8fd1-11eb-924d-9cd76263cbd0,,,wfo-0001249600,7705343,,
 87c17d4e-8fcd-11eb-924d-9cd76263cbd0,species,antennata,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 334 1899",,,,,,634423-1,wfo-0000959670,5311544,,
 87c1cb0a-8fcd-11eb-924d-9cd76263cbd0,species,antennisepala,Eulophia,,"(Rchb.f.) Schltr.",,1900,,"Westafr. Kautschuk-Exped. 279 1900",,,,,,634424-1,wfo-0000959673,5311531,,
 87c1e4d2-8fcd-11eb-924d-9cd76263cbd0,species,antunesii,Eulophia,,Rolfe,,1889,,"Bol. Soc. Brot. 7: 236 1889",,,,,,634425-1,wfo-0000959674,5311776,,
-87c201b0-8fcd-11eb-924d-9cd76263cbd0,species,arenaria,Eulophia,,"(Lindl.) Bolus",,1898,,"J. Linn. Soc., Bot. 25: 185 1898","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634426-1,wfo-0000959675,5311626,,
+87c201b0-8fcd-11eb-924d-9cd76263cbd0,species,arenaria,Eulophia,,"(Lindl.) Bolus",,1898,,"J. Linn. Soc., Bot. 25: 185 1898","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634426-1,wfo-0000959675,5311626,,
 87c21eac-8fcd-11eb-924d-9cd76263cbd0,species,arenicola,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634427-1,wfo-0000959676,5311745,,
 87c23af4-8fcd-11eb-924d-9cd76263cbd0,species,argentina,Eulophia,,"(Rolfe) Schltr.",,1915,,"Bot. Jahrb. Syst. 53: 574 1915",,,,ff32ccfe-8fcb-11eb-924d-9cd76263cbd0,,634428-1,wfo-0000959677,5312019,,
 87c2561a-8fcd-11eb-924d-9cd76263cbd0,species,aristata,Eulophia,,Rendle,,1895,,"J. Bot. 33: 169 1895",,,,,,634429-1,wfo-0000959678,5311297,,
@@ -96,10 +57,7 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c2ca1e-8fcd-11eb-924d-9cd76263cbd0,species,aurantiaca,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634433-1,wfo-0000959682,5311465,,
 87c2fe94-8fcd-11eb-924d-9cd76263cbd0,species,aurea,Eulophia,,Kraenzl.,,1897,,"Bull. Herb. Boissier 5: 635 1897",,,,,,634434-1,wfo-0000959684,5311357,,
 87c3192e-8fcd-11eb-924d-9cd76263cbd0,species,austrooccidentalis,Eulophia,,Sölch,,1956,,"Mitt. Bot. Staatssamml. München 2: 177 1956",,,,,,,wfo-0000959685,5311523,,
-87c33648-8fcd-11eb-924d-9cd76263cbd0,species,badinii,Eulophia,,R.J.V.Alves,,1991,,"Folia Geobot. Phytotax. 26: 102 1991","Alves, R. J. V. (1991). A new species of the genus Eulophia R. Br. (Orchidaceae) from Minas Gerais, Brazil. Folia Geobotanica Et Phytotaxonomica, 26(1), 101–106. https://doi.org/10.1007/bf02912945
-
-
-",Q55755442,DOI:10.1007/bf02912945,,,959817-1,wfo-0000959686,5543354,,
+87c33648-8fcd-11eb-924d-9cd76263cbd0,species,badinii,Eulophia,,R.J.V.Alves,,1991,,"Folia Geobot. Phytotax. 26: 102 1991","Alves, R. J. V. (1991). A new species of the genus Eulophia R. Br. (Orchidaceae) from Minas Gerais, Brazil. Folia Geobotanica Et Phytotaxonomica, 26(1), 101–106. https://doi.org/10.1007/bf02912945",Q55755442,DOI:10.1007/bf02912945,,,959817-1,wfo-0000959686,5543354,,
 87c353f8-8fcd-11eb-924d-9cd76263cbd0,species,baginsensis,Eulophia,,Rchb.f.,,1878,,"Otia Bot. Hamburg. 66 1878",,,,,,634436-1,wfo-0000959687,5311787,,
 87c370d6-8fcd-11eb-924d-9cd76263cbd0,species,bainesii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 65 1897",,,,,,634437-1,wfo-0000959688,5312005,,
 87c38a94-8fcd-11eb-924d-9cd76263cbd0,species,bakeri,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 40 1912",,,,,,634438-1,wfo-0000959689,5311998,,
@@ -111,10 +69,7 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c443a8-8fcd-11eb-924d-9cd76263cbd0,species,baumiana,Eulophia,,Kraenzl.,,1903,,"Kunene-Sambesi Exped. 213 1903",,,,,,634445-1,wfo-0000959696,5311299,,
 87c45d20-8fcd-11eb-924d-9cd76263cbd0,species,bella,Eulophia,,N.E.Br.,,1889,,"Gard. Chron. III, 6: 210 1889",,,,,,,wfo-0000959697,5312122,,
 87c47936-8fcd-11eb-924d-9cd76263cbd0,species,beravensis,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 74 1881",,,,,,634448-1,wfo-0000959698,5311876,,
-87c49344-8fcd-11eb-924d-9cd76263cbd0,species,bicallosa,Eulophia,,"(D.Don) P.F.Hunt & Summerh.",,1966,,"Kew Bull. 20: 60 1966","Hunt, P. F., & Summerhayes, V. S. (1966). Notes on Asiatic Orchids: IV. Kew Bulletin, 20(1), 51–61. https://doi.org/10.2307/4107882
-
-
-",Q43250382,DOI:10.2307/4107882,2179caa6-8fcc-11eb-924d-9cd76263cbd0,,634449-1,wfo-0000959699,5311839,,
+87c49344-8fcd-11eb-924d-9cd76263cbd0,species,bicallosa,Eulophia,,"(D.Don) P.F.Hunt & Summerh.",,1966,,"Kew Bull. 20: 60 1966","Hunt, P. F., & Summerhayes, V. S. (1966). Notes on Asiatic Orchids: IV. Kew Bulletin, 20(1), 51–61. https://doi.org/10.2307/4107882",Q43250382,DOI:10.2307/4107882,2179caa6-8fcc-11eb-924d-9cd76263cbd0,,634449-1,wfo-0000959699,5311839,,
 87c4b0f4-8fcd-11eb-924d-9cd76263cbd0,variety,major,Eulophia,bicallosa,"(King & Pantl.) Pradhan",,1979,,"Indian Orchids: Guide Identif. & Cult. 2: 461 1979",,,,87c4e9ca-8fcd-11eb-924d-9cd76263cbd0,,887509-1,wfo-0000959700,5311846,,
 87c4cd28-8fcd-11eb-924d-9cd76263cbd0,species,bicarinata,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 6 1890",,,,,,634450-1,wfo-0000959701,5311842,,
 87c4e9ca-8fcd-11eb-924d-9cd76263cbd0,variety,major,Eulophia,bicarinata,"King & Pantl.",,1898,,"Ann. Roy. Bot. Gard. (Calcutta) 8: 181 1898",,,,,,,wfo-0000959702,5311848,,
@@ -130,14 +85,8 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c62204-8fcd-11eb-924d-9cd76263cbd0,species,bletilloides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 576 1915",,,,,,634459-1,wfo-0000959713,5311821,,
 87c63dd4-8fcd-11eb-924d-9cd76263cbd0,species,boltonii,Eulophia,,"Harv. ex Rolfe",,1912,,"Fl. Cap. 5(3): 53 1912",,,,,,634460-1,wfo-0000959714,5312074,,
 545a1e62-8fcc-11eb-924d-9cd76263cbd0,species,borbonica,Eulophia,,Bosser,,2002,,"Adansonia III, 24: 22 2002",,,,,,20006676-1,wfo-0000416190,5311891,,
-87c657a6-8fcd-11eb-924d-9cd76263cbd0,species,borneensis,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 31: 289 1896","Ridley, H. N. (1896). An Enumeration of all Orchideae hitherto recorded from Borneo. Transactions of the Linnean Society of London: Botany, 31(215), 261–306. https://doi.org/10.1111/j.1095-8339.1896.tb00808.x
-
-
-",Q55760384,DOI:10.1111/j.1095-8339.1896.tb00808.x,,,634462-1,wfo-0000959715,5312077,,
-87c670a6-8fcd-11eb-924d-9cd76263cbd0,species,bouharmontii,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940391-1,wfo-0000959716,5311744,,
+87c657a6-8fcd-11eb-924d-9cd76263cbd0,species,borneensis,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 31: 289 1896","Ridley, H. N. (1896). An Enumeration of all Orchideae hitherto recorded from Borneo. Transactions of the Linnean Society of London: Botany, 31(215), 261–306. https://doi.org/10.1111/j.1095-8339.1896.tb00808.x",Q55760384,DOI:10.1111/j.1095-8339.1896.tb00808.x,,,634462-1,wfo-0000959715,5312077,,
+87c670a6-8fcd-11eb-924d-9cd76263cbd0,species,bouharmontii,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940391-1,wfo-0000959716,5311744,,
 87c68e06-8fcd-11eb-924d-9cd76263cbd0,species,bouliawongo,Eulophia,,"(Rchb.f.) J.Raynal",,1965,,"Rev. Soc. Savantes Haute Normandie 1965: 47 1966",,,,8b88ffce-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959717,5312022,,
 87c6a774-8fcd-11eb-924d-9cd76263cbd0,species,brachycentra,Eulophia,,Hayata,,1914,,"Icon. Pl. Formosan. 4: 72 1914",,,,,,634463-1,wfo-0000959718,5311841,,
 87c6c416-8fcd-11eb-924d-9cd76263cbd0,species,brachypetala,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 24 1858",,,,,,634464-1,wfo-0000959719,5311473,,
@@ -145,64 +94,34 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c6f972-8fcd-11eb-924d-9cd76263cbd0,species,bracteosa,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,,wfo-0000959721,5311923,,
 87c715b0-8fcd-11eb-924d-9cd76263cbd0,species,brenanii,Eulophia,,"P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 536 1998",,,,,,1005718-1,wfo-0000959722,5311881,,
 87c73068-8fcd-11eb-924d-9cd76263cbd0,species,brevipetala,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 53 1897",,,,,,634467-1,wfo-0000959723,5311835,,
-87c74cf6-8fcd-11eb-924d-9cd76263cbd0,species,brevisepala,Eulophia,,"(Rendle) Summerh.",,1953,,"Kew Bull. 8: 147 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
-
-
-",Q55784833,DOI:10.2307/4117167,,,634468-1,wfo-0000959724,5311501,,
-87c769ac-8fcd-11eb-924d-9cd76263cbd0,species,brunnea,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634469-1,wfo-0000959725,5311538,,
+87c74cf6-8fcd-11eb-924d-9cd76263cbd0,species,brevisepala,Eulophia,,"(Rendle) Summerh.",,1953,,"Kew Bull. 8: 147 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167",Q55784833,DOI:10.2307/4117167,,,634468-1,wfo-0000959724,5311501,,
+87c769ac-8fcd-11eb-924d-9cd76263cbd0,species,brunnea,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634469-1,wfo-0000959725,5311538,,
 87c7a476-8fcd-11eb-924d-9cd76263cbd0,species,brunneorubra,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 583 1915",,,,,,634470-1,wfo-0000959727,5311364,,
 87c7f7aa-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 19 1894",,,,,,634472-1,wfo-0000959730,7367438,,
-87c7bfc4-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634471-1,wfo-0000959728,5311397,,
+87c7bfc4-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634471-1,wfo-0000959728,5311397,,
 87c7db44-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 64 1897",,,,,,634473-1,wfo-0000959729,7481908,,
 87c8129e-8fcd-11eb-924d-9cd76263cbd0,species,buettneri,Eulophia,,"(Kraenzl.) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 446 1936",,,,db490fc4-8fcb-11eb-924d-9cd76263cbd0,,634474-1,wfo-0000959731,5311560,,
-87c82fae-8fcd-11eb-924d-9cd76263cbd0,species,bulbinoides,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 234 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634475-1,wfo-0000959732,5311448,,
-87c84c00-8fcd-11eb-924d-9cd76263cbd0,species,burkei,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477
-
-
-",Q55778673,DOI:10.2307/4107477,,,634476-1,wfo-0000959733,5312150,,
+87c82fae-8fcd-11eb-924d-9cd76263cbd0,species,bulbinoides,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 234 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634475-1,wfo-0000959732,5311448,,
+87c84c00-8fcd-11eb-924d-9cd76263cbd0,species,burkei,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477",Q55778673,DOI:10.2307/4107477,,,634476-1,wfo-0000959733,5312150,,
 87c8685c-8fcd-11eb-924d-9cd76263cbd0,species,burmanica,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 5 1890",,,,,,634477-1,wfo-0000959734,5311417,,
 87c8829c-8fcd-11eb-924d-9cd76263cbd0,species,burundiensis,Eulophia,,"Arbonn. & Geerinck",,1993,,"Belgian J. Bot. 126: 257 1993 publ. 1994",,,,,,976618-1,wfo-0000959735,5311333,,
-87c89f5c-8fcd-11eb-924d-9cd76263cbd0,species,busseana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634478-1,wfo-0000959736,5311961,,
+87c89f5c-8fcd-11eb-924d-9cd76263cbd0,species,busseana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634478-1,wfo-0000959736,5311961,,
 87c8d724-8fcd-11eb-924d-9cd76263cbd0,species,caffra,Eulophia,,Rchb.f.,,1865,,"Flora 48: 186 1865",,,,,,634479-1,wfo-0000959738,5311783,,
 87c8f380-8fcd-11eb-924d-9cd76263cbd0,species,calantha,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 215 1903",,,,,,634480-1,wfo-0000959739,5312062,,
 87c9116c-8fcd-11eb-924d-9cd76263cbd0,variety,kubangensis,Eulophia,calantha,Schltr.,,1903,,"Kunene-Sambesi Exped. 216 1903",,,,,,,wfo-0000959740,5312065,,
 87c92d5a-8fcd-11eb-924d-9cd76263cbd0,species,calanthoides,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 1 1895",,,,,,634481-1,wfo-0000959741,5312011,,
 87c9493e-8fcd-11eb-924d-9cd76263cbd0,species,calcarata,Eulophia,,"(Schltr.) Schltr.",,1925,,"Repert. Spec. Nov. Regni Veg. Beih. 33: 262 1925",,,,,,634482-1,wfo-0000959742,5323757,,
 87c96586-8fcd-11eb-924d-9cd76263cbd0,species,callichroma,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 116 1881",,,,,,634483-1,wfo-0000959743,5311898,,
-87c9819c-8fcd-11eb-924d-9cd76263cbd0,species,caloptera,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 133 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211
-
-
-",Q43263417,DOI:10.2307/4109211,,,634484-1,wfo-0000959744,5311521,,
-87c99f74-8fcd-11eb-924d-9cd76263cbd0,species,cambodiensis,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
-
-
-",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634485-1,wfo-0000959745,5311772,,
+87c9819c-8fcd-11eb-924d-9cd76263cbd0,species,caloptera,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 133 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211",Q43263417,DOI:10.2307/4109211,,,634484-1,wfo-0000959744,5311521,,
+87c99f74-8fcd-11eb-924d-9cd76263cbd0,species,cambodiensis,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634485-1,wfo-0000959745,5311772,,
 87c9bcb6-8fcd-11eb-924d-9cd76263cbd0,species,campanulata,Eulophia,,Duthie,,1902,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 71: 39 1902",,,,,,634486-1,wfo-0000959746,5311826,,
 87c9da20-8fcd-11eb-924d-9cd76263cbd0,species,campbellii,Eulophia,,Prain,,1904,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 73: 190 1904",,,,,,634487-1,wfo-0000959747,5311778,,
 c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Numer. List n. 7367 1828",,,,,,634488-1,wfo-0001088105,8085160,,
 87ca1044-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,"Wall. ex Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,,wfo-0000959749,5311488,,
 87ca2a66-8fcd-11eb-924d-9cd76263cbd0,species,camporum,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 170 1913",,,,,,634489-1,wfo-0000959750,5311889,,
 87ca4532-8fcd-11eb-924d-9cd76263cbd0,species,candida,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 6 1890",,,,,,634490-1,wfo-0000959751,5311849,,
-87ca5eaa-8fcd-11eb-924d-9cd76263cbd0,species,candidiflora,Eulophia,,Butzin,,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634491-1,wfo-0000959752,5311677,,
-87ca7b06-8fcd-11eb-924d-9cd76263cbd0,species,capensis,Eulophia,,"(L.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
-
-
-",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634492-1,wfo-0000959753,5311571,,
+87ca5eaa-8fcd-11eb-924d-9cd76263cbd0,species,candidiflora,Eulophia,,Butzin,,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634491-1,wfo-0000959752,5311677,,
+87ca7b06-8fcd-11eb-924d-9cd76263cbd0,species,capensis,Eulophia,,"(L.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634492-1,wfo-0000959753,5311571,,
 87ca9726-8fcd-11eb-924d-9cd76263cbd0,species,caricifolia,Eulophia,,"(Rchb.f.) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634493-1,wfo-0000959754,5311525,,
 87cab2e2-8fcd-11eb-924d-9cd76263cbd0,variety,antennisepala,Eulophia,caricifolia,"(Rchb.f.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 647 1992",,,,,,967482-1,wfo-0000959755,,,
 87cad01a-8fcd-11eb-924d-9cd76263cbd0,species,carinata,Eulophia,,"(Willd.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 183 1833",,,,,,634494-1,wfo-0000959756,5311550,,
@@ -211,31 +130,19 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cb21aa-8fcd-11eb-924d-9cd76263cbd0,species,carunculifera,Eulophia,,Rchb.f.,,1881,,"Flora 64: 329 1881",,,,,,634497-1,wfo-0000959759,5311400,,
 87cb3bd6-8fcd-11eb-924d-9cd76263cbd0,species,celebica,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634498-1,wfo-0000959760,5312134,,
 87cb55d0-8fcd-11eb-924d-9cd76263cbd0,species,chaunanthe,Eulophia,,Seidenf.,,1983,,"Opera Bot. 72: 34 1983 publ. 1984",,,,,,904162-1,wfo-0000959761,5312084,,
-87cb6fc0-8fcd-11eb-924d-9cd76263cbd0,species,chilangensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555
-
-
-",Q55778719,DOI:10.2307/4107555,,,634499-1,wfo-0000959762,5312057,,
+87cb6fc0-8fcd-11eb-924d-9cd76263cbd0,species,chilangensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555",Q55778719,DOI:10.2307/4107555,,,634499-1,wfo-0000959762,5312057,,
 87cb8bfe-8fcd-11eb-924d-9cd76263cbd0,species,chlorantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 9 1895",,,,,,634500-1,wfo-0000959763,5312008,,
 87cba864-8fcd-11eb-924d-9cd76263cbd0,species,chlorotica,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 389 1914",,,,,,634501-1,wfo-0000959764,5311747,,
 87cbc2d6-8fcd-11eb-924d-9cd76263cbd0,species,chrysantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 2 1895",,,,,,634502-1,wfo-0000959765,5311371,,
 87cbdece-8fcd-11eb-924d-9cd76263cbd0,species,chrysoglossoides,Eulophia,,Schltr.,,1906,,"Bull. Herb. Boissier II, 6: 453 1906",,,,,,634503-1,wfo-0000959766,5311932,,
-87cbf850-8fcd-11eb-924d-9cd76263cbd0,species,chrysops,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634504-1,wfo-0000959767,5311324,,
+87cbf850-8fcd-11eb-924d-9cd76263cbd0,species,chrysops,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634504-1,wfo-0000959767,5311324,,
 87cc14e8-8fcd-11eb-924d-9cd76263cbd0,species,ciliata,Eulophia,,"(Schumach.) Rchb.f.",,1863,,"Ann. Bot. Syst. 6: 647 1863",,,,fef87f1e-8fb1-11eb-924d-9cd76263cbd0,,634505-1,wfo-0000959768,5311454,,
-87cc4b16-8fcd-11eb-924d-9cd76263cbd0,species,circinnata,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719
-
-
-",Q55781794,DOI:10.2307/4111719,,,634506-1,wfo-0000959770,5311781,,
+87cc4b16-8fcd-11eb-924d-9cd76263cbd0,species,circinnata,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719",Q55781794,DOI:10.2307/4111719,,,634506-1,wfo-0000959770,5311781,,
 87cc66d2-8fcd-11eb-924d-9cd76263cbd0,species,clandestina,Eulophia,,"(Börge Pett.) Bytebier",,2008,,"Strelitzia 22: 190 2008",,,,ff332316-8fcb-11eb-924d-9cd76263cbd0,,77095523-1,wfo-0000959771,5311823,,
 87cc82d4-8fcd-11eb-924d-9cd76263cbd0,species,clavicornis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634507-1,wfo-0000959772,5311386,,
 87ccc014-8fcd-11eb-924d-9cd76263cbd0,variety,inaequalis,Eulophia,clavicornis,"(Schltr.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 82 1965",,,,,,,wfo-0000959774,5311412,,
 87ccdcde-8fcd-11eb-924d-9cd76263cbd0,variety,nutans,Eulophia,clavicornis,"(Sond.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 82 1965",,,,87f32420-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959775,5311393,,
-87ccf8b8-8fcd-11eb-924d-9cd76263cbd0,species,clitellifera,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634508-1,wfo-0000959776,5311598,,
+87ccf8b8-8fcd-11eb-924d-9cd76263cbd0,species,clitellifera,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634508-1,wfo-0000959776,5311598,,
 87cd1578-8fcd-11eb-924d-9cd76263cbd0,species,coccifera,Eulophia,,"Frapp. ex Cordem.",,1895,,"Fl. Réunion 222 1895",,,,,,634509-1,wfo-0000959777,5311582,,
 87cd3148-8fcd-11eb-924d-9cd76263cbd0,species,cochlearis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634511-1,wfo-0000959778,5312506,,
 87cd4ad4-8fcd-11eb-924d-9cd76263cbd0,species,coddii,Eulophia,,A.V.Hall,,1965,,"J. S. African Bot. Suppl. 5: 134 1965",,,,,,634512-1,wfo-0000959779,5311495,,
@@ -244,10 +151,7 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cdd40e-8fcd-11eb-924d-9cd76263cbd0,species,collina,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 336 1899",,,,,,634515-1,wfo-0000959784,5311594,,
 87cdedcc-8fcd-11eb-924d-9cd76263cbd0,species,comosa,Eulophia,,Sond.,,1846,,"Linnaea 19: 72 1846",,,,,,634516-1,wfo-0000959785,5312510,,
 87ce09f6-8fcd-11eb-924d-9cd76263cbd0,species,complanata,Eulophia,,Verd.,,,,"Fl. Pl. Africa 27: t. 1056 1949",,,,,,634517-1,wfo-0000959786,5312003,,
-87ce23c8-8fcd-11eb-924d-9cd76263cbd0,species,compta,Eulophia,,Summerh.,,1951,,"Kew Bull. 6: 472 1951 publ. 1952","Summerhayes, V. S. (1951). African Orchids: XX. Kew Bulletin, 6(3), 461–475. https://doi.org/10.2307/4118030
-
-
-",Q43261270,DOI:10.2307/4118030,,,634518-1,wfo-0000959787,5311321,,
+87ce23c8-8fcd-11eb-924d-9cd76263cbd0,species,compta,Eulophia,,Summerh.,,1951,,"Kew Bull. 6: 472 1951 publ. 1952","Summerhayes, V. S. (1951). African Orchids: XX. Kew Bulletin, 6(3), 461–475. https://doi.org/10.2307/4118030",Q43261270,DOI:10.2307/4118030,,,634518-1,wfo-0000959787,5311321,,
 87ce40d8-8fcd-11eb-924d-9cd76263cbd0,species,concinna,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 581 1915",,,,,,634519-1,wfo-0000959788,5312038,,
 87ce5ae6-8fcd-11eb-924d-9cd76263cbd0,species,concolor,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,da681d20-8fcb-11eb-924d-9cd76263cbd0,,634520-1,wfo-0000959789,5308340,,
 87ce74f4-8fcd-11eb-924d-9cd76263cbd0,species,congoensis,Eulophia,,Cogn.,,1895,,"J. Orchidées 6: 155 1895",,,,,,,wfo-0000959790,5311865,,
@@ -255,14 +159,8 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cec8fa-8fcd-11eb-924d-9cd76263cbd0,species,corallorhiziformis,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 9 1895",,,,,,634524-1,wfo-0000959793,5311450,,
 87cee484-8fcd-11eb-924d-9cd76263cbd0,species,cordylinophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 541 1885",,,,,,634525-1,wfo-0000959794,5323774,,
 87cefdd4-8fcd-11eb-924d-9cd76263cbd0,species,corymbosa,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 216 1903",,,,,,634526-1,wfo-0000959795,5311870,,
-87cf199a-8fcd-11eb-924d-9cd76263cbd0,species,coutreziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940392-1,wfo-0000959796,5311512,,
-87cf3588-8fcd-11eb-924d-9cd76263cbd0,species,crepidata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634527-1,wfo-0000959797,5311721,,
+87cf199a-8fcd-11eb-924d-9cd76263cbd0,species,coutreziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940392-1,wfo-0000959796,5311512,,
+87cf3588-8fcd-11eb-924d-9cd76263cbd0,species,crepidata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634527-1,wfo-0000959797,5311721,,
 87cf6ef4-8fcd-11eb-924d-9cd76263cbd0,species,crinita,Eulophia,,"(P.N.Don) G.Don",,1850,,"Suppl. Hort. Brit. 588 1850",,,,,,,wfo-0000959799,7721138,,
 87cf5298-8fcd-11eb-924d-9cd76263cbd0,species,crinita,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 58 1897",,,,,,634529-1,wfo-0000959798,5310370,,
 87cf88da-8fcd-11eb-924d-9cd76263cbd0,species,cristata,Eulophia,,"(Afzel. ex Sw.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000959800,5311673,,
@@ -270,33 +168,18 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 545c53b2-8fcc-11eb-924d-9cd76263cbd0,variety,dilecta,Eulophia,cucullata,"(Rchb.f.) Pérez-Vera",,2003,,"Orchidées Côte D'Ivoire 321 2003",,,,,,70027675-1,wfo-0000416197,,,
 af44d89e-8fd1-11eb-924d-9cd76263cbd0,species,cullenii,Eulophia,,"(Wight) C.E.C.Fisch.",,,,"Fl. Madras 1435 1928",,,,7d2c5f5c-8fcd-11eb-924d-9cd76263cbd0,,634534-1,wfo-0001223208,7942127,,
 87cfd984-8fcd-11eb-924d-9cd76263cbd0,species,cullenii,Eulophia,,"(Wight) Blume",,1859,,"Coll. Orchid. 182 1859",,,,7d2c5f5c-8fcd-11eb-924d-9cd76263cbd0,,634533-1,wfo-0000959803,5311462,,
-87cff32e-8fcd-11eb-924d-9cd76263cbd0,species,culveri,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634535-1,wfo-0000959804,5311573,,
+87cff32e-8fcd-11eb-924d-9cd76263cbd0,species,culveri,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634535-1,wfo-0000959804,5311573,,
 87d00f26-8fcd-11eb-924d-9cd76263cbd0,species,cyrtosioides,Eulophia,,Schltr.,,1900,,"Westafr. Kautschuk-Exped. 279 1900",,,,,,634536-1,wfo-0000959805,5311834,,
 af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr.",,1970,,"J. Bombay Nat. Hist. Soc. 67: 66 1970",,,,21ab52ec-8fcc-11eb-924d-9cd76263cbd0,,,wfo-0001223229,8263740,,
 87d02b32-8fcd-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) Hochr.",,1910,,"Bull. New York Bot. Gard. 6: 270 1910",,,,21ab52ec-8fcc-11eb-924d-9cd76263cbd0,,634538-1,wfo-0000959806,5311480,,
-87d044f0-8fcd-11eb-924d-9cd76263cbd0,species,dactylifera,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 163 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,634540-1,wfo-0000959807,5311419,,
+87d044f0-8fcd-11eb-924d-9cd76263cbd0,species,dactylifera,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 163 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,634540-1,wfo-0000959807,5311419,,
 87d06318-8fcd-11eb-924d-9cd76263cbd0,species,dahliana,Eulophia,,Kraenzl.,,1896,,"Notizbl. Königl. Bot. Gart. Berlin 1: 243 1896",,,,,,634541-1,wfo-0000959808,5311335,,
 87d0800a-8fcd-11eb-924d-9cd76263cbd0,species,debeerstii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 111 1919",,,,,,634543-1,wfo-0000959809,5312079,,
 87d09c2a-8fcd-11eb-924d-9cd76263cbd0,species,decaryana,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935",,,,,,,wfo-0000959810,5323759,,
 87d0b836-8fcd-11eb-924d-9cd76263cbd0,species,decipiens,Eulophia,,Kurz,,1876,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 45(2): 155 1876",,,,,,634545-1,wfo-0000959811,5312158,,
-87d0f0bc-8fcd-11eb-924d-9cd76263cbd0,species,decurva,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 235 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634546-1,wfo-0000959813,5311404,,
-87d10caa-8fcd-11eb-924d-9cd76263cbd0,species,deflexa,Eulophia,,Rolfe,,1895,,"Bull. Misc. Inform. Kew 1895: 192 1895","New Orchids.: Decade 14. (1895). Bulletin of Miscellaneous Information, 1895(104), 191. https://doi.org/10.2307/4114968
-
-
-",Q55783766,DOI:10.2307/4114968,,,634547-1,wfo-0000959814,5311999,,
-87d12622-8fcd-11eb-924d-9cd76263cbd0,species,delicata,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 169 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,634548-1,wfo-0000959815,5311421,,
+87d0f0bc-8fcd-11eb-924d-9cd76263cbd0,species,decurva,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 235 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634546-1,wfo-0000959813,5311404,,
+87d10caa-8fcd-11eb-924d-9cd76263cbd0,species,deflexa,Eulophia,,Rolfe,,1895,,"Bull. Misc. Inform. Kew 1895: 192 1895","New Orchids.: Decade 14. (1895). Bulletin of Miscellaneous Information, 1895(104), 191. https://doi.org/10.2307/4114968",Q55783766,DOI:10.2307/4114968,,,634547-1,wfo-0000959814,5311999,,
+87d12622-8fcd-11eb-924d-9cd76263cbd0,species,delicata,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 169 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,634548-1,wfo-0000959815,5311421,,
 87d14210-8fcd-11eb-924d-9cd76263cbd0,species,densiflora,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634549-1,wfo-0000959816,5311972,,
 87d15b9c-8fcd-11eb-924d-9cd76263cbd0,species,dentata,Eulophia,,Ames,,1911,,"Philipp. J. Sci., C 6: 51 1911",,,,,,634550-1,wfo-0000959817,5311904,,
 87d17582-8fcd-11eb-924d-9cd76263cbd0,species,descampsii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 81 1919",,,,,,634551-1,wfo-0000959818,5311319,,
@@ -309,139 +192,76 @@ af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr
 87d24b56-8fcd-11eb-924d-9cd76263cbd0,species,dissimilis,Eulophia,,R.A.Dyer,,,,"Fl. Pl. Africa 27: t. 1066 1949",,,,,,634559-1,wfo-0000959826,5323731,,
 87d26802-8fcd-11eb-924d-9cd76263cbd0,species,divergens,Eulophia,,Fritsch,,,,"Bull. Herb. Boissier II, 1: 1118 1901",,,,,,,wfo-0000959827,5311622,,
 87d2842c-8fcd-11eb-924d-9cd76263cbd0,species,dregeana,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634561-1,wfo-0000959828,5311997,,
-87d29dcc-8fcd-11eb-924d-9cd76263cbd0,species,dufossei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
-
-
-",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634562-1,wfo-0000959829,5311535,,
-87d2b9d8-8fcd-11eb-924d-9cd76263cbd0,species,durbanensis,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 83 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
-
-
-",Q55782426,DOI:10.2307/4113400,,,634563-1,wfo-0000959830,5311369,,
+87d29dcc-8fcd-11eb-924d-9cd76263cbd0,species,dufossei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634562-1,wfo-0000959829,5311535,,
+87d2b9d8-8fcd-11eb-924d-9cd76263cbd0,species,durbanensis,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 83 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400",Q55782426,DOI:10.2307/4113400,,,634563-1,wfo-0000959830,5311369,,
 87d2d35a-8fcd-11eb-924d-9cd76263cbd0,species,dusenii,Eulophia,,Kraenzl.,,1894,,"Bot. Jahrb. Syst. 19: 254 1894",,,,,,634564-1,wfo-0000959831,5311314,,
-87d2ef48-8fcd-11eb-924d-9cd76263cbd0,species,dybowskii,Eulophia,,"(God.-Leb.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db4f4c0e-8fcb-11eb-924d-9cd76263cbd0,,634565-1,wfo-0000959832,5311659,,
+87d2ef48-8fcd-11eb-924d-9cd76263cbd0,species,dybowskii,Eulophia,,"(God.-Leb.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db4f4c0e-8fcb-11eb-924d-9cd76263cbd0,,634565-1,wfo-0000959832,5311659,,
 87d32832-8fcd-11eb-924d-9cd76263cbd0,species,ecalcarata,Eulophia,,G.Will.,,1980,,"J. S. African Bot. 46: 336 1980",,,,,,634566-1,wfo-0000959834,5311820,,
-87d34434-8fcd-11eb-924d-9cd76263cbd0,species,ecarinata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634567-1,wfo-0000959835,5311561,,
+87d34434-8fcd-11eb-924d-9cd76263cbd0,species,ecarinata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634567-1,wfo-0000959835,5311561,,
 87d3605e-8fcd-11eb-924d-9cd76263cbd0,species,ecristata,Eulophia,,"(Fernald) Ames",,1904,,"Contr. Ames Bot. Lab. 1: 19 1904",,,,,,99294-2,wfo-0000959836,5312154,,
 87d37be8-8fcd-11eb-924d-9cd76263cbd0,species,elamellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 112 1919",,,,,,634569-1,wfo-0000959837,5311360,,
 87d3954c-8fcd-11eb-924d-9cd76263cbd0,species,elata,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 3 1890",,,,,,634570-1,wfo-0000959838,5312130,,
 87d3ae4c-8fcd-11eb-924d-9cd76263cbd0,species,elegans,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 585 1915",,,,,,634571-1,wfo-0000959839,5312010,,
-87d3c7e2-8fcd-11eb-924d-9cd76263cbd0,species,elegantula,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
-
-
-",Q55782426,DOI:10.2307/4113400,,,634572-1,wfo-0000959840,5312171,,
-87d3e59c-8fcd-11eb-924d-9cd76263cbd0,species,eleogena,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634573-1,wfo-0000959841,5311663,,
+87d3c7e2-8fcd-11eb-924d-9cd76263cbd0,species,elegantula,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400",Q55782426,DOI:10.2307/4113400,,,634572-1,wfo-0000959840,5312171,,
+87d3e59c-8fcd-11eb-924d-9cd76263cbd0,species,eleogena,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634573-1,wfo-0000959841,5311663,,
 87d403ba-8fcd-11eb-924d-9cd76263cbd0,species,elliottii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 54 1897",,,,,,634575-1,wfo-0000959842,,,
 87d43c22-8fcd-11eb-924d-9cd76263cbd0,species,elongata,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634576-1,wfo-0000959844,5312148,,
 87d455f4-8fcd-11eb-924d-9cd76263cbd0,species,emarginata,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634577-1,wfo-0000959845,5311385,,
 87d4707a-8fcd-11eb-924d-9cd76263cbd0,species,emarginata,Eulophia,,Blume,,1859,,"Coll. Orchid. 180 1859",,,,,,634578-1,wfo-0000959846,7609323,,
 87d48ab0-8fcd-11eb-924d-9cd76263cbd0,species,emilianae,Eulophia,,C.J.Saldanha,,1974,,"Indian Forester 100: 566 1974",,,,,,,wfo-0000959847,5311775,,
 87d4a752-8fcd-11eb-924d-9cd76263cbd0,species,encyclioides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 577 1915",,,,,,634580-1,wfo-0000959848,5312059,,
-87d4c156-8fcd-11eb-924d-9cd76263cbd0,species,endlichiana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634581-1,wfo-0000959849,5543321,,
-87d4daa6-8fcd-11eb-924d-9cd76263cbd0,species,engleri,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
-
-
-",Q55781795,DOI:10.2307/4111720,,,634582-1,wfo-0000959850,5311409,,
+87d4c156-8fcd-11eb-924d-9cd76263cbd0,species,endlichiana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634581-1,wfo-0000959849,5543321,,
+87d4daa6-8fcd-11eb-924d-9cd76263cbd0,species,engleri,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720",Q55781795,DOI:10.2307/4111720,,,634582-1,wfo-0000959850,5311409,,
 87d4f7d4-8fcd-11eb-924d-9cd76263cbd0,species,ensata,Eulophia,,Lindl.,,,,"Bot. Reg. 14: t. 1147 1828",,,,,,634583-1,wfo-0000959851,5311616,,
-87d51458-8fcd-11eb-924d-9cd76263cbd0,species,ephippium,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634584-1,wfo-0000959852,5311583,,
+87d51458-8fcd-11eb-924d-9cd76263cbd0,species,ephippium,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634584-1,wfo-0000959852,5311583,,
 87d52e3e-8fcd-11eb-924d-9cd76263cbd0,species,epidendraea,Eulophia,,"(J.Koenig ex Retz.) C.E.C.Fisch.",,,,"Fl. Madras 1434 1928",,,,0c3943ce-8fcc-11eb-924d-9cd76263cbd0,,634585-1,wfo-0000959853,5311546,,
 87d56854-8fcd-11eb-924d-9cd76263cbd0,species,epidendroides,Eulophia,,"(Willd.) Schltr.",,1914,,"Orchideen 346 1914",,,,da69ee70-8fcb-11eb-924d-9cd76263cbd0,,634586-1,wfo-0000959855,5311553,,
 87d581ea-8fcd-11eb-924d-9cd76263cbd0,species,epiphanoides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 575 1915",,,,,,634587-1,wfo-0000959856,5311464,,
 545df2bc-8fcc-11eb-924d-9cd76263cbd0,species,epiphytica,Eulophia,,"P.J.Cribb, Du Puy & Bosser",,2002,,"Adansonia III, 24: 170 2002",,,,,,20010520-1,wfo-0000416207,5313537,,
-87d59ba8-8fcd-11eb-924d-9cd76263cbd0,species,ernestii,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634588-1,wfo-0000959857,5311402,,
+87d59ba8-8fcd-11eb-924d-9cd76263cbd0,species,ernestii,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634588-1,wfo-0000959857,5311402,,
 87d5b796-8fcd-11eb-924d-9cd76263cbd0,species,euantha,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 586 1915",,,,,,634589-1,wfo-0000959858,5311377,,
 87d5d154-8fcd-11eb-924d-9cd76263cbd0,species,euglossa,Eulophia,,"(Rchb.f.) Rchb.f. ex Bateman",,,,"Bot. Mag. 92: t. 5561 1866",,,,,,,wfo-0000959859,5311313,,
 87d5ee14-8fcd-11eb-924d-9cd76263cbd0,species,eustachya,Eulophia,,"(Rchb.f.) Geerinck",,1988,,"Fl. Rwanda 4: 572 1988",,,,,,945341-1,wfo-0000959860,5311300,,
-87d607dc-8fcd-11eb-924d-9cd76263cbd0,species,evrardii,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
-
-
-",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634591-1,wfo-0000959861,5305372,,
+87d607dc-8fcd-11eb-924d-9cd76263cbd0,species,evrardii,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634591-1,wfo-0000959861,5305372,,
 87d623c0-8fcd-11eb-924d-9cd76263cbd0,species,exaltata,Eulophia,,Rchb.f.,,1857,,"Bonplandia (Hannover) 5: 38 1857",,,,,,634592-1,wfo-0000959862,5312051,,
 87d63ee6-8fcd-11eb-924d-9cd76263cbd0,variety,sarasinorum,Eulophia,exaltata,Schltr.,,1925,,"Repert. Spec. Nov. Regni Veg. 21: 195 1925",,,,,,,wfo-0000959863,5312053,,
 87d65bec-8fcd-11eb-924d-9cd76263cbd0,species,excavata,Eulophia,,Butzin,,1957,,"Willdenowia 7: 588 1957",,,,,,,wfo-0000959864,5311609,,
 87d693b4-8fcd-11eb-924d-9cd76263cbd0,species,exilis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 581 1915",,,,,,634594-1,wfo-0000959866,5312035,,
 87d6affc-8fcd-11eb-924d-9cd76263cbd0,species,explanata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,634595-1,wfo-0000959867,5311967,,
 87d6cadc-8fcd-11eb-924d-9cd76263cbd0,species,eylesii,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 194 1937",,,,,,634596-1,wfo-0000959868,5311927,,
-87d70420-8fcd-11eb-924d-9cd76263cbd0,species,faberi,Eulophia,,Rolfe,,1896,,"Bull. Misc. Inform. Kew 1896: 198 1896","New Orchids.: Decades 17-20. (1896). Bulletin of Miscellaneous Information, 1896(119), 193. https://doi.org/10.2307/4118450
-
-
-",Q55786096,DOI:10.2307/4118450,,,634597-1,wfo-0000959870,5311482,,
+87d70420-8fcd-11eb-924d-9cd76263cbd0,species,faberi,Eulophia,,Rolfe,,1896,,"Bull. Misc. Inform. Kew 1896: 198 1896","New Orchids.: Decades 17-20. (1896). Bulletin of Miscellaneous Information, 1896(119), 193. https://doi.org/10.2307/4118450",Q55786096,DOI:10.2307/4118450,,,634597-1,wfo-0000959870,5311482,,
 87d72090-8fcd-11eb-924d-9cd76263cbd0,species,falcatiloba,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 660 2001",,,,,,20000664-1,wfo-0000959871,5311774,,
 87d739cc-8fcd-11eb-924d-9cd76263cbd0,species,faradjensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 83 1919",,,,,,634598-1,wfo-0000959872,5311936,,
 87d75448-8fcd-11eb-924d-9cd76263cbd0,species,farcta,Eulophia,,G.Will.,,1980,,"J. S. African Bot. 46: 337 1980",,,,,,634599-1,wfo-0000959873,5311822,,
-87d7705e-8fcd-11eb-924d-9cd76263cbd0,species,fernandeziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 184 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940393-1,wfo-0000959874,5311687,,
+87d7705e-8fcd-11eb-924d-9cd76263cbd0,species,fernandeziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 184 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940393-1,wfo-0000959874,5311687,,
 87d7a6a0-8fcd-11eb-924d-9cd76263cbd0,species,filicaulis,Eulophia,,Lindl.,,1842,,"Ann. Mag. Nat. Hist. 10: 184 1842",,,,,,634600-1,wfo-0000959876,5543316,,
 87d7c0e0-8fcd-11eb-924d-9cd76263cbd0,species,filifolia,Eulophia,,"Bosser & Morat",,2001,,"Adansonia III, 23: 18 2001",,,,,,1021152-1,wfo-0000959877,5311668,,
 87d7dd32-8fcd-11eb-924d-9cd76263cbd0,species,fitzalanii,Eulophia,,F.Muell.,,1872,,"Fragm. 8: 30 1872",,,,,,,wfo-0000959878,5311840,,
 87d7f8e4-8fcd-11eb-924d-9cd76263cbd0,species,flaccida,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 3 1895",,,,,,634602-1,wfo-0000959879,5311596,,
 87d81298-8fcd-11eb-924d-9cd76263cbd0,species,flammea,Eulophia,,Kraenzl.,,1912,,"Bot. Jahrb. Syst. 48: 395 1912",,,,,,634603-1,wfo-0000959880,5311355,,
-87d830a2-8fcd-11eb-924d-9cd76263cbd0,species,flanaganii,Eulophia,,Bolus,,1905,,"Trans. S. African Philos. Soc. 16: 143 1905","Bolus, H. (1905). CONTRIBUTIONS TO THE AFRICAN FLORA. The Transactions of the South African Philosophical Society, 16(1), 135–152. https://doi.org/10.1080/21560382.1905.9526051
-
-
-",Q56148769,DOI:10.1080/21560382.1905.9526051,,,634604-1,wfo-0000959881,5311389,,
+87d830a2-8fcd-11eb-924d-9cd76263cbd0,species,flanaganii,Eulophia,,Bolus,,1905,,"Trans. S. African Philos. Soc. 16: 143 1905","Bolus, H. (1905). CONTRIBUTIONS TO THE AFRICAN FLORA. The Transactions of the South African Philosophical Society, 16(1), 135–152. https://doi.org/10.1080/21560382.1905.9526051",Q56148769,DOI:10.1080/21560382.1905.9526051,,,634604-1,wfo-0000959881,5311389,,
 87d84db2-8fcd-11eb-924d-9cd76263cbd0,species,flava,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 7 1890",,,,,,634605-1,wfo-0000959882,5311458,,
 87d869be-8fcd-11eb-924d-9cd76263cbd0,species,flavopurpurea,Eulophia,,"(Rchb.f.) Rolfe",,1897,,"Fl. Trop. Afr. 7: 65 1897",,,,7d2cebd4-8fcd-11eb-924d-9cd76263cbd0,,634606-1,wfo-0000959883,5311341,,
 87d8861a-8fcd-11eb-924d-9cd76263cbd0,species,flexuosa,Eulophia,,"(Rolfe) Gilg",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,634607-1,wfo-0000959884,5307903,,
 87d89fec-8fcd-11eb-924d-9cd76263cbd0,species,florulenta,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 66 1902",,,,,,634608-1,wfo-0000959885,5311817,,
-87d8f794-8fcd-11eb-924d-9cd76263cbd0,species,foliosa,Eulophia,,"(Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 337 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
-
-
-",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634609-1,wfo-0000959888,5312071,,
-87d91404-8fcd-11eb-924d-9cd76263cbd0,species,formosana,Eulophia,,"(Rolfe) Rolfe",,1903,,"J. Linn. Soc., Bot. 36: 28 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x
-
-
-",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,634610-1,wfo-0000959889,5311694,,
-87d92f84-8fcd-11eb-924d-9cd76263cbd0,species,fractiflexa,Eulophia,,Summerh.,,1953,,"Kew Bull. 8: 156 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
-
-
-",Q55784833,DOI:10.2307/4117167,,,634611-1,wfo-0000959890,5311602,,
+87d8f794-8fcd-11eb-924d-9cd76263cbd0,species,foliosa,Eulophia,,"(Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 337 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634609-1,wfo-0000959888,5312071,,
+87d91404-8fcd-11eb-924d-9cd76263cbd0,species,formosana,Eulophia,,"(Rolfe) Rolfe",,1903,,"J. Linn. Soc., Bot. 36: 28 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,634610-1,wfo-0000959889,5311694,,
+87d92f84-8fcd-11eb-924d-9cd76263cbd0,species,fractiflexa,Eulophia,,Summerh.,,1953,,"Kew Bull. 8: 156 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167",Q55784833,DOI:10.2307/4117167,,,634611-1,wfo-0000959890,5311602,,
 87d94bae-8fcd-11eb-924d-9cd76263cbd0,species,fragrans,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 27 1895",,,,,,634612-1,wfo-0000959891,5311964,,
 87d96760-8fcd-11eb-924d-9cd76263cbd0,species,fridericii,Eulophia,,"(Rchb.f.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 131 1965",,,,db51dafa-8fcb-11eb-924d-9cd76263cbd0,,634613-1,wfo-0000959892,5311974,,
 87d98330-8fcd-11eb-924d-9cd76263cbd0,species,friesii,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 247 1916",,,,,,634614-1,wfo-0000959893,5312021,,
 87d99ffa-8fcd-11eb-924d-9cd76263cbd0,species,fusca,Eulophia,,"(Wight) Blume",,1859,,"Coll. Orchid. 182 1859",,,,7d2d5e2a-8fcd-11eb-924d-9cd76263cbd0,,634615-1,wfo-0000959894,5312141,,
-87d9bf80-8fcd-11eb-924d-9cd76263cbd0,species,galbana,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 469 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
-
-
-",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634616-1,wfo-0000959895,5306002,,
+87d9bf80-8fcd-11eb-924d-9cd76263cbd0,species,galbana,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 469 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634616-1,wfo-0000959895,5306002,,
 87d9de48-8fcd-11eb-924d-9cd76263cbd0,species,galeoloides,Eulophia,,Kraenzl.,,1898,,"Bot. Jahrb. Syst. 24: 508 1898",,,,,,634617-1,wfo-0000959896,5311832,,
 87da03b4-8fcd-11eb-924d-9cd76263cbd0,species,galpinii,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 10 1895",,,,,,634618-1,wfo-0000959897,5311398,,
 87da56ca-8fcd-11eb-924d-9cd76263cbd0,species,gastrodioides,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 337 1899",,,,,,634619-1,wfo-0000959899,5311767,,
 87da7402-8fcd-11eb-924d-9cd76263cbd0,species,geniculata,Eulophia,,"King & Pantl.",,1895,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 64(2): 337 1895",,,,,,,wfo-0000959900,5311893,,
 87da9432-8fcd-11eb-924d-9cd76263cbd0,species,gigantea,Eulophia,,"(Welw. ex Rchb.f.) N.E.Br.",,1889,,"Bull. Misc. Inform. Kew 1889: 90 1889",,,,,,,wfo-0000959901,5312028,,
-87dab368-8fcd-11eb-924d-9cd76263cbd0,species,gilletiana,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634623-1,wfo-0000959902,5311952,,
-87dad276-8fcd-11eb-924d-9cd76263cbd0,species,gladioloides,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
-
-
-",Q55781795,DOI:10.2307/4111720,,,634624-1,wfo-0000959903,5311388,,
+87dab368-8fcd-11eb-924d-9cd76263cbd0,species,gilletiana,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634623-1,wfo-0000959902,5311952,,
+87dad276-8fcd-11eb-924d-9cd76263cbd0,species,gladioloides,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720",Q55781795,DOI:10.2307/4111720,,,634624-1,wfo-0000959903,5311388,,
 87daee5a-8fcd-11eb-924d-9cd76263cbd0,species,goetzeana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 372 1900",,,,,,634625-1,wfo-0000959904,5311833,,
 87db09e4-8fcd-11eb-924d-9cd76263cbd0,species,gonychila,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634626-1,wfo-0000959905,5311536,,
-87db264a-8fcd-11eb-924d-9cd76263cbd0,species,gracilior,Eulophia,,"(Rendle) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634627-1,wfo-0000959906,5311940,,
+87db264a-8fcd-11eb-924d-9cd76263cbd0,species,gracilior,Eulophia,,"(Rendle) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634627-1,wfo-0000959906,5311940,,
 87db4580-8fcd-11eb-924d-9cd76263cbd0,species,gracilis,Eulophia,,Lindl.,,1823,,"Bot. Reg. 9: t. 742 1823",,,,,,634628-1,wfo-0000959907,5311451,,
 87db64de-8fcd-11eb-924d-9cd76263cbd0,species,graciliscapa,Eulophia,,Schltr.,,1897,,"Bot. Jahrb. Syst. 24: 418 1897",,,,,,634629-1,wfo-0000959908,5311374,,
 87db9f08-8fcd-11eb-924d-9cd76263cbd0,species,gracillima,Eulophia,,Ridl.,,1886,,"J. Bot. 24: 292 1886",,,,,,634630-1,wfo-0000959910,5311445,,
@@ -449,21 +269,12 @@ af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr
 87dbd8ce-8fcd-11eb-924d-9cd76263cbd0,species,graminea,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,,wfo-0000959912,5312157,,
 87dc097a-8fcd-11eb-924d-9cd76263cbd0,variety,kitamurae,Eulophia,graminea,"(Masam.) S.S.Ying",,1977,,"Col. Ill. Indig. Orch. Taiwan 1(2): 455 1977",,,,87e415a2-8fcd-11eb-924d-9cd76263cbd0,,887510-1,wfo-0000959913,5311906,,
 87dc69ba-8fcd-11eb-924d-9cd76263cbd0,species,grandibractea,Eulophia,,Kraenzl.,,1923,,"Mitt. Inst. Allg. Bot. Hamburg 5: 238 1923",,,,,,634633-1,wfo-0000959914,5311475,,
-87dc87c4-8fcd-11eb-924d-9cd76263cbd0,species,grandidieri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 149 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634634-1,wfo-0000959915,5312041,,
+87dc87c4-8fcd-11eb-924d-9cd76263cbd0,species,grandidieri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 149 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634634-1,wfo-0000959915,5312041,,
 87dca4ac-8fcd-11eb-924d-9cd76263cbd0,species,grandiflora,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,634635-1,wfo-0000959916,5311924,,
 87dcbfaa-8fcd-11eb-924d-9cd76263cbd0,species,granducalis,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 340 1909",,,,,,634636-1,wfo-0000959917,5311910,,
-af63c092-8fd1-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7(3): 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634637-1,wfo-0001223435,8017248,,
+af63c092-8fd1-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7(3): 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634637-1,wfo-0001223435,8017248,,
 87dcdd28-8fcd-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Cufod.",,,,"Bull. Jard. Bot. État 42(3): 1615 1972",,,,,,,wfo-0000959918,5311522,,
-87dcfa88-8fcd-11eb-924d-9cd76263cbd0,species,grantii,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 148 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
-
-
-",Q55784833,DOI:10.2307/4117167,db571556-8fcb-11eb-924d-9cd76263cbd0,,634638-1,wfo-0000959919,5311732,,
+87dcfa88-8fcd-11eb-924d-9cd76263cbd0,species,grantii,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 148 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167",Q55784833,DOI:10.2307/4117167,db571556-8fcb-11eb-924d-9cd76263cbd0,,634638-1,wfo-0000959919,5311732,,
 87dd323c-8fcd-11eb-924d-9cd76263cbd0,species,guamensis,Eulophia,,Ames,,1914,,"Philipp. J. Sci., C 9: 12 1914",,,,,,634639-1,wfo-0000959921,5311753,,
 c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"Bot. Reg. 8: t. 686 1823",,,,,,,wfo-0001088132,7383573,,
 87dd4ca4-8fcd-11eb-924d-9cd76263cbd0,species,guineensis,Eulophia,,Lindl.,,1823,,"Bot. Reg. 8: t. 686 1823",,,,,,634640-1,wfo-0000959922,5311862,,
@@ -473,10 +284,7 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87ddbfd6-8fcd-11eb-924d-9cd76263cbd0,species,gumbariensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 117 1919",,,,,,634641-1,wfo-0000959926,5311788,,
 87dddd72-8fcd-11eb-924d-9cd76263cbd0,species,gusukumae,Eulophia,,Masam.,,1934,,"Trans. Nat. Hist. Soc. Taiwan 24: 208 1934",,,,,,634642-1,wfo-0000959927,5312161,,
 87ddf7f8-8fcd-11eb-924d-9cd76263cbd0,species,hastata,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634643-1,wfo-0000959928,5305369,,
-87de14cc-8fcd-11eb-924d-9cd76263cbd0,species,haygarthii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
-
-
-",Q55782219,DOI:10.2307/4113249,,,634644-1,wfo-0000959929,5312000,,
+87de14cc-8fcd-11eb-924d-9cd76263cbd0,species,haygarthii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249",Q55782219,DOI:10.2307/4113249,,,634644-1,wfo-0000959929,5312000,,
 87de2ef8-8fcd-11eb-924d-9cd76263cbd0,species,helleborina,Eulophia,,Hook.f.,,,,"Bot. Mag. 96: t. 5875 1870",,,,,,634645-1,wfo-0000959930,5311291,,
 87deb0e4-8fcd-11eb-924d-9cd76263cbd0,species,hemileuca,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634646-1,wfo-0000959932,5311490,,
 87decd90-8fcd-11eb-924d-9cd76263cbd0,species,herbacea,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634647-1,wfo-0000959933,5311469,,
@@ -485,35 +293,20 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87df1fc0-8fcd-11eb-924d-9cd76263cbd0,variety,inaequalis,Eulophia,hians,"(Schltr.) S.Thomas",,1998,,"Lindleyana 13: 183 1998",,,,,,1004906-1,wfo-0000959936,5311408,,
 87df3c26-8fcd-11eb-924d-9cd76263cbd0,variety,nutans,Eulophia,hians,"(Sond.) S.Thomas",,1998,,"Lindleyana 13: 183 1998",,,,87f32420-8fcd-11eb-924d-9cd76263cbd0,,1004905-1,wfo-0000959937,5311387,,
 87df567a-8fcd-11eb-924d-9cd76263cbd0,species,hildebrandii,Eulophia,,Schltr.,,1919,,"Repert. Spec. Nov. Regni Veg. Beih. 4: 262 1919",,,,,,634650-1,wfo-0000959938,5312139,,
-87df72e0-8fcd-11eb-924d-9cd76263cbd0,species,hirschbergii,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634651-1,wfo-0000959939,5312056,,
+87df72e0-8fcd-11eb-924d-9cd76263cbd0,species,hirschbergii,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634651-1,wfo-0000959939,5312056,,
 87dfa74c-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,T.P.Lin,,1987,,"Native Orchids Taiwan 3: 68 1987",,,,,,934110-1,wfo-0000959941,7615066,,
-87df8c8a-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,"J.Joseph & Vajr.",,1975,,"Bull. Bot. Surv. India 17: 192 1975 publ. 1978","Joseph, J., & Vajravelu, E. (1975). Eulophia Hirsuta Joseph et Vajravelu (Orchidaceae) - a New Species from South India. Bulletin of the Botanical Survey of India, 17(1-4), 192-194. https://doi.org/10.20324/nelumbo/v17/1975/75827
-
-
-",Q101074629,DOI:10.20324/nelumbo/v17/1975/75827,,,634652-1,wfo-0000959940,5319562,,
+87df8c8a-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,"J.Joseph & Vajr.",,1975,,"Bull. Bot. Surv. India 17: 192 1975 publ. 1978","Joseph, J., & Vajravelu, E. (1975). Eulophia Hirsuta Joseph et Vajravelu (Orchidaceae) - a New Species from South India. Bulletin of the Botanical Survey of India, 17(1-4), 192-194. https://doi.org/10.20324/nelumbo/v17/1975/75827",Q101074629,DOI:10.20324/nelumbo/v17/1975/75827,,,634652-1,wfo-0000959940,5319562,,
 87dfe036-8fcd-11eb-924d-9cd76263cbd0,species,hockii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 120 1919",,,,,,634653-1,wfo-0000959943,5311819,,
 87dffbde-8fcd-11eb-924d-9cd76263cbd0,species,holochila,Eulophia,,"Collett & Hemsl.",,1890,,"J. Linn. Soc., Bot. 28: 132 1890",,,,,,634654-1,wfo-0000959944,5312149,,
 87e01916-8fcd-11eb-924d-9cd76263cbd0,species,hologlossa,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 171 1913",,,,,,634655-1,wfo-0000959945,5311930,,
 87e038a6-8fcd-11eb-924d-9cd76263cbd0,species,holstiana,Eulophia,,Kraenzl.,,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,,wfo-0000959946,5311370,,
 87e05494-8fcd-11eb-924d-9cd76263cbd0,species,holtzei,Eulophia,,F.Muell.,,1889,,"Victorian Naturalist 6: 55 1889",,,,,,634657-1,wfo-0000959947,5319578,,
 87e06f10-8fcd-11eb-924d-9cd76263cbd0,species,holubii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634658-1,wfo-0000959948,5311859,,
-87e08a68-8fcd-11eb-924d-9cd76263cbd0,species,homblei,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634659-1,wfo-0000959949,5311496,,
+87e08a68-8fcd-11eb-924d-9cd76263cbd0,species,homblei,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634659-1,wfo-0000959949,5311496,,
 87e0a55c-8fcd-11eb-924d-9cd76263cbd0,species,hormusjii,Eulophia,,Duthie,,1906,,"Ann. Roy. Bot. Gard. (Calcutta) 9(2): 125 1906",,,,,,634660-1,wfo-0000959950,5311486,,
 87e0bfb0-8fcd-11eb-924d-9cd76263cbd0,species,horsfallii,Eulophia,,"(Bateman) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,db5c7064-8fcb-11eb-924d-9cd76263cbd0,,634661-1,wfo-0000959951,5311649,,
-87e0dcde-8fcd-11eb-924d-9cd76263cbd0,species,huillensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634662-1,wfo-0000959952,5311643,,
-87e11690-8fcd-11eb-924d-9cd76263cbd0,species,humbertii,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634663-1,wfo-0000959954,5323765,,
+87e0dcde-8fcd-11eb-924d-9cd76263cbd0,species,huillensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634662-1,wfo-0000959952,5311643,,
+87e11690-8fcd-11eb-924d-9cd76263cbd0,species,humbertii,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634663-1,wfo-0000959954,5323765,,
 87e14dc2-8fcd-11eb-924d-9cd76263cbd0,species,humilis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 165 1895",,,,,,634664-1,wfo-0000959956,7376289,,
 87e1308a-8fcd-11eb-924d-9cd76263cbd0,species,humilis,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 337 1899",,,,,,634665-1,wfo-0000959955,5311593,,
 87e1699c-8fcd-11eb-924d-9cd76263cbd0,species,huttonii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 52 1912",,,,,,634666-1,wfo-0000959957,5311567,,
@@ -525,76 +318,40 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87e21068-8fcd-11eb-924d-9cd76263cbd0,species,inconspicua,Eulophia,,Griff.,,1851,,"Not. Pl. Asiat. 3: 349 1851",,,,,,634673-1,wfo-0000959963,5312159,,
 87e250b4-8fcd-11eb-924d-9cd76263cbd0,species,involuta,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 442 1936",,,,,,634674-1,wfo-0000959965,5311328,,
 87e26b30-8fcd-11eb-924d-9cd76263cbd0,species,inyangensis,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 195 1937",,,,,,634675-1,wfo-0000959966,5311861,,
-87e286ce-8fcd-11eb-924d-9cd76263cbd0,species,ischna,Eulophia,,Summerh.,,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113
-
-
-",Q55779620,DOI:10.2307/4109113,,,634676-1,wfo-0000959967,5311880,,
+87e286ce-8fcd-11eb-924d-9cd76263cbd0,species,ischna,Eulophia,,Summerh.,,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113",Q55779620,DOI:10.2307/4109113,,,634676-1,wfo-0000959967,5311880,,
 87e2a0be-8fcd-11eb-924d-9cd76263cbd0,species,javanica,Eulophia,,J.J.Sm.,,1921,,"Bull. Jard. Bot. Buitenzorg III, 3: 260 1921",,,,,,634677-1,wfo-0000959968,5311979,,
 87e2bc48-8fcd-11eb-924d-9cd76263cbd0,species,johnstonii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 66 1897",,,,,,634678-1,wfo-0000959969,5311373,,
 87e2d606-8fcd-11eb-924d-9cd76263cbd0,species,jumelleana,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 172 1913",,,,,,634679-1,wfo-0000959970,5311937,,
-87e2f3a2-8fcd-11eb-924d-9cd76263cbd0,species,juncifolia,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634680-1,wfo-0000959971,5311869,,
+87e2f3a2-8fcd-11eb-924d-9cd76263cbd0,species,juncifolia,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634680-1,wfo-0000959971,5311869,,
 87e3122e-8fcd-11eb-924d-9cd76263cbd0,species,junodiana,Eulophia,,Kraenzl.,,1897,,"Bull. Herb. Boissier 5: 634 1897",,,,,,634681-1,wfo-0000959972,5311436,,
 87e32e6c-8fcd-11eb-924d-9cd76263cbd0,species,kamarupa,Eulophia,,Sud.Chowdhury,,1993,,"J. Orchid Soc. India 7: 49 1993",,,,,,1008706-1,wfo-0000959973,5311814,,
 87e34b0e-8fcd-11eb-924d-9cd76263cbd0,species,katangensis,Eulophia,,"(De Wild.) De Wild.",,1919,,"Bull. Jard. Bot. État 6: 121 1919",,,,,,634682-1,wfo-0000959974,5311768,,
-87e38204-8fcd-11eb-924d-9cd76263cbd0,species,keiliana,Eulophia,,"(Kraenzl.) Butzin",,1973,,"Willdenowia 7: 588 1973","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,90a13bfc-8fcd-11eb-924d-9cd76263cbd0,,634683-1,wfo-0000959976,5311650,,
-87e39e74-8fcd-11eb-924d-9cd76263cbd0,species,keithii,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 32: 333 1896","Ridley, H. (1896). The Orchideae and Apostasiaceae of the Malay Peninsula. Transactions of the Linnean Society of London: Botany, 32(220-227), 213–416. https://doi.org/10.1111/j.1095-8339.1896.tb00698.x
-
-
-",Q55760377,DOI:10.1111/j.1095-8339.1896.tb00698.x,,,634684-1,wfo-0000959977,5311303,,
-87e3bb0c-8fcd-11eb-924d-9cd76263cbd0,species,keniensis,Eulophia,,Schltr.,,1924,,"Notizbl. Bot. Gart. Berlin-Dahlem 9: 21 1924","Fries, R. E., Fries, T. C. E., & Schlechter, R. (1924). Beitrage zur Kenntnis der Flora des Kenia, Mt. Aberdare und Mt. Elgon. V. Notizblatt Des Königl. Botanischen Gartens Und Museums Zu Berlin, 9(81), 16. https://doi.org/10.2307/3994426
-
-
-",Q55777118,DOI:10.2307/3994426,,,634685-1,wfo-0000959978,5311415,,
+87e38204-8fcd-11eb-924d-9cd76263cbd0,species,keiliana,Eulophia,,"(Kraenzl.) Butzin",,1973,,"Willdenowia 7: 588 1973","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,90a13bfc-8fcd-11eb-924d-9cd76263cbd0,,634683-1,wfo-0000959976,5311650,,
+87e39e74-8fcd-11eb-924d-9cd76263cbd0,species,keithii,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 32: 333 1896","Ridley, H. (1896). The Orchideae and Apostasiaceae of the Malay Peninsula. Transactions of the Linnean Society of London: Botany, 32(220-227), 213–416. https://doi.org/10.1111/j.1095-8339.1896.tb00698.x",Q55760377,DOI:10.1111/j.1095-8339.1896.tb00698.x,,,634684-1,wfo-0000959977,5311303,,
+87e3bb0c-8fcd-11eb-924d-9cd76263cbd0,species,keniensis,Eulophia,,Schltr.,,1924,,"Notizbl. Bot. Gart. Berlin-Dahlem 9: 21 1924","Fries, R. E., Fries, T. C. E., & Schlechter, R. (1924). Beitrage zur Kenntnis der Flora des Kenia, Mt. Aberdare und Mt. Elgon. V. Notizblatt Des Königl. Botanischen Gartens Und Museums Zu Berlin, 9(81), 16. https://doi.org/10.2307/3994426",Q55777118,DOI:10.2307/3994426,,,634685-1,wfo-0000959978,5311415,,
 87e3d52e-8fcd-11eb-924d-9cd76263cbd0,species,kirkii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 58 1897",,,,,,634686-1,wfo-0000959979,5312030,,
 87e3f22a-8fcd-11eb-924d-9cd76263cbd0,species,kisanfuensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 93 1919",,,,,,634687-1,wfo-0000959980,5311983,,
 87e415a2-8fcd-11eb-924d-9cd76263cbd0,species,kitamurae,Eulophia,,Masam.,,1932,,"J. Soc. Trop. Agric. 4: 192 1932",,,,,,634688-1,wfo-0000959981,5311907,,
-87e43186-8fcd-11eb-924d-9cd76263cbd0,species,kondensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634689-1,wfo-0000959982,5311631,,
-87e44d60-8fcd-11eb-924d-9cd76263cbd0,species,krebsii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db5ef91a-8fcb-11eb-924d-9cd76263cbd0,,634690-1,wfo-0000959983,5311742,,
+87e43186-8fcd-11eb-924d-9cd76263cbd0,species,kondensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634689-1,wfo-0000959982,5311631,,
+87e44d60-8fcd-11eb-924d-9cd76263cbd0,species,krebsii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db5ef91a-8fcb-11eb-924d-9cd76263cbd0,,634690-1,wfo-0000959983,5311742,,
 87e466d8-8fcd-11eb-924d-9cd76263cbd0,species,kyimbilae,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 584 1915",,,,,,634691-1,wfo-0000959984,5311418,,
 87e48078-8fcd-11eb-924d-9cd76263cbd0,species,lachnocheila,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 2 1890",,,,,,634692-1,wfo-0000959985,5311334,,
-87e4ba20-8fcd-11eb-924d-9cd76263cbd0,species,lambii,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503
-
-
-",Q55787805,DOI:10.2307/4119503,,,634693-1,wfo-0000959987,5312031,,
-87e4d3de-8fcd-11eb-924d-9cd76263cbd0,species,lambinoniana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 185 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940394-1,wfo-0000959988,5311901,,
+87e4ba20-8fcd-11eb-924d-9cd76263cbd0,species,lambii,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503",Q55787805,DOI:10.2307/4119503,,,634693-1,wfo-0000959987,5312031,,
+87e4d3de-8fcd-11eb-924d-9cd76263cbd0,species,lambinoniana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 185 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940394-1,wfo-0000959988,5311901,,
 87e4efcc-8fcd-11eb-924d-9cd76263cbd0,species,lamellata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 184 1833",,,,,,634694-1,wfo-0000959989,5312507,,
-87e5094e-8fcd-11eb-924d-9cd76263cbd0,species,lanceata,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 156 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634695-1,wfo-0000959990,5323784,,
+87e5094e-8fcd-11eb-924d-9cd76263cbd0,species,lanceata,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 156 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634695-1,wfo-0000959990,5323784,,
 87e5258c-8fcd-11eb-924d-9cd76263cbd0,species,lanceolata,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634696-1,wfo-0000959991,5311294,,
 87e53f5e-8fcd-11eb-924d-9cd76263cbd0,species,lata,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634697-1,wfo-0000959992,5311356,,
 87e55c1e-8fcd-11eb-924d-9cd76263cbd0,species,latifolia,Eulophia,,Rolfe,,1891,,"Bol. Soc. Brot. 9: 139 1891",,,,,,634698-1,wfo-0000959993,5323766,,
 87e57a6e-8fcd-11eb-924d-9cd76263cbd0,species,latilabris,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634699-1,wfo-0000959994,5311950,,
 87e59a12-8fcd-11eb-924d-9cd76263cbd0,species,latipetala,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 41 1912",,,,,,634700-1,wfo-0000959995,5312113,,
 87e5b524-8fcd-11eb-924d-9cd76263cbd0,species,laurentiana,Eulophia,,Kraenzl.,,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 60 1899",,,,,,,wfo-0000959996,5311456,,
-87e606aa-8fcd-11eb-924d-9cd76263cbd0,species,laurentii,Eulophia,,"(De Wild.) Summerh.",,1960,,"Kew Bull. 14: 139 1960","Summerhayes, V. S. (1960). African Orchids: XXVII. Kew Bulletin, 14(1), 126. https://doi.org/10.2307/4115580
-
-
-",Q55784110,DOI:10.2307/4115580,,,634702-1,wfo-0000959999,5311829,,
+87e606aa-8fcd-11eb-924d-9cd76263cbd0,species,laurentii,Eulophia,,"(De Wild.) Summerh.",,1960,,"Kew Bull. 14: 139 1960","Summerhayes, V. S. (1960). African Orchids: XXVII. Kew Bulletin, 14(1), 126. https://doi.org/10.2307/4115580",Q55784110,DOI:10.2307/4115580,,,634702-1,wfo-0000959999,5311829,,
 87e62356-8fcd-11eb-924d-9cd76263cbd0,species,laxiflora,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 4 1895",,,,,,634703-1,wfo-0000960000,5311401,,
 87e63f94-8fcd-11eb-924d-9cd76263cbd0,species,leachii,Eulophia,,"Greatrex ex A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 161 1965",,,,,,634704-1,wfo-0000960001,5311766,,
 87e65a06-8fcd-11eb-924d-9cd76263cbd0,species,ledermannii,Eulophia,,Kraenzl.,,1912,,"Bot. Jahrb. Syst. 48: 394 1912",,,,,,634705-1,wfo-0000960002,5312044,,
 87e6764e-8fcd-11eb-924d-9cd76263cbd0,species,ledienii,Eulophia,,"Stein ex N.E.Br.",,1889,,"Bull. Misc. Inform. Kew 1889: 90 1889",,,,,,,wfo-0000960003,5323738,,
-87e692e6-8fcd-11eb-924d-9cd76263cbd0,species,lejolyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940395-1,wfo-0000960004,5311621,,
+87e692e6-8fcd-11eb-924d-9cd76263cbd0,species,lejolyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940395-1,wfo-0000960004,5311621,,
 545f6732-8fcc-11eb-924d-9cd76263cbd0,species,lenbrassii,Eulophia,,Ormerod,,2003,,"Oasis 2(4): 4 2003",,,,,,70028093-1,wfo-0000416216,5311427,,
 87e6aef2-8fcd-11eb-924d-9cd76263cbd0,species,leonensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 51 1897",,,,,,634707-1,wfo-0000960005,5311589,,
 87e6c8ec-8fcd-11eb-924d-9cd76263cbd0,species,leontoglossa,Eulophia,,Rchb.f.,,1881,,"Flora 64: 329 1881",,,,,,634708-1,wfo-0000960006,5311557,,
@@ -611,19 +368,10 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87e82296-8fcd-11eb-924d-9cd76263cbd0,species,lisowskii,Eulophia,,Szlach.,,1993,,"Fragm. Florist. Geobot. 38: 461 1993",,,,,,976600-1,wfo-0000960018,5312046,,
 87e83ee8-8fcd-11eb-924d-9cd76263cbd0,species,lissochiloides,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 203 1837",,,,,,634717-1,wfo-0000960019,5311438,,
 87e891e0-8fcd-11eb-924d-9cd76263cbd0,species,litoralis,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 338 1899",,,,,,634718-1,wfo-0000960021,5311970,,
-87e8b51c-8fcd-11eb-924d-9cd76263cbd0,species,livingstoneana,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 132 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211
-
-
-",Q43263417,DOI:10.2307/4109211,,,634719-1,wfo-0000960022,5311933,,
+87e8b51c-8fcd-11eb-924d-9cd76263cbd0,species,livingstoneana,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 132 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211",Q43263417,DOI:10.2307/4109211,,,634719-1,wfo-0000960022,5311933,,
 ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.) Schltr.",,1913,,"Ann. Mus. Colon. Marseille, sér. 3, 1: 172 1913",,,,,,634720-1,wfo-0001243813,5543290,,
-87e8e4b0-8fcd-11eb-924d-9cd76263cbd0,species,lokobensis,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 153 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634721-1,wfo-0000960023,5323773,,
-87e90d46-8fcd-11eb-924d-9cd76263cbd0,species,lomamiensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634722-1,wfo-0000960024,5311951,,
+87e8e4b0-8fcd-11eb-924d-9cd76263cbd0,species,lokobensis,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 153 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634721-1,wfo-0000960023,5323773,,
+87e90d46-8fcd-11eb-924d-9cd76263cbd0,species,lomamiensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634722-1,wfo-0000960024,5311951,,
 87e934ce-8fcd-11eb-924d-9cd76263cbd0,species,lonchophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 542 1885",,,,,,634723-1,wfo-0000960025,5323732,,
 87e962c8-8fcd-11eb-924d-9cd76263cbd0,species,longibracteata,Eulophia,,"(Lindl.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 22 1894",,,,,,634725-1,wfo-0000960026,5311680,,
 87e98a0a-8fcd-11eb-924d-9cd76263cbd0,species,longicollis,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,634726-1,wfo-0000960027,5308352,,
@@ -631,22 +379,10 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87e9c772-8fcd-11eb-924d-9cd76263cbd0,species,longifolia,Eulophia,,"(Kunth) Schltr.",,1914,,"Orchideen 347 1914",,,,,,99296-2,wfo-0000960029,5311797,,
 309c1aba-8fcd-11eb-924d-9cd76263cbd0,variety,amazonica,Eulophia,longifolia,"(Barb.Rodr.) Cogn.",,1942,,"Fl. Bras. 12(6): 4 1942",,,,,,99297-2,wfo-0000795139,7964353,,
 1cc480be-8fcc-11eb-924d-9cd76263cbd0,variety,flavescens,Eulophia,longifolia,Schltr.,,1922,,"Anexos Mem. Inst. Butantan, Secc. Bot. 1(4): 62 1922",,,,,,99298-2,wfo-0000336473,5311806,,
-87e9e824-8fcd-11eb-924d-9cd76263cbd0,species,longilobata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634730-1,wfo-0000960030,5311957,,
-87ea037c-8fcd-11eb-924d-9cd76263cbd0,species,longipedunculata,Eulophia,,Rendle,,1895,,"J. Linn. Soc., Bot. 30: 383 1895","Rendle, A. B. (1895). A Contribution to the Flora of Eastern Tropical Africa. Transactions of the Linnean Society of London: Botany, 30(210), 373–435. https://doi.org/10.1111/j.1095-8339.1894.tb02417.x
-
-
-",Q55760371,DOI:10.1111/j.1095-8339.1894.tb02417.x,,,634724-1,wfo-0000960031,5311789,,
-87ea1ed4-8fcd-11eb-924d-9cd76263cbd0,species,longipes,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719
-
-
-",Q55781794,DOI:10.2307/4111719,,,634731-1,wfo-0000960032,5311416,,
-87ea3932-8fcd-11eb-924d-9cd76263cbd0,species,longisepala,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 43 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
-
-
-",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634732-1,wfo-0000960033,5311541,,
+87e9e824-8fcd-11eb-924d-9cd76263cbd0,species,longilobata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634730-1,wfo-0000960030,5311957,,
+87ea037c-8fcd-11eb-924d-9cd76263cbd0,species,longipedunculata,Eulophia,,Rendle,,1895,,"J. Linn. Soc., Bot. 30: 383 1895","Rendle, A. B. (1895). A Contribution to the Flora of Eastern Tropical Africa. Transactions of the Linnean Society of London: Botany, 30(210), 373–435. https://doi.org/10.1111/j.1095-8339.1894.tb02417.x",Q55760371,DOI:10.1111/j.1095-8339.1894.tb02417.x,,,634724-1,wfo-0000960031,5311789,,
+87ea1ed4-8fcd-11eb-924d-9cd76263cbd0,species,longipes,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719",Q55781794,DOI:10.2307/4111719,,,634731-1,wfo-0000960032,5311416,,
+87ea3932-8fcd-11eb-924d-9cd76263cbd0,species,longisepala,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 43 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634732-1,wfo-0000960033,5311541,,
 87ea5638-8fcd-11eb-924d-9cd76263cbd0,species,lubbersiana,Eulophia,,"De Wild. & Laurent",,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 135 1899",,,,,,,wfo-0000960034,5323751,,
 87ea72b2-8fcd-11eb-924d-9cd76263cbd0,species,lujae,Eulophia,,"De Wild.",,1904,,"Pl. Nov. Horti Then. t. 17 1904",,,,,,634735-1,wfo-0000960035,5311913,,
 87ea8cac-8fcd-11eb-924d-9cd76263cbd0,species,lujaeana,Eulophia,,Kraenzl.,,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 217 1899",,,,,,,wfo-0000960036,5311446,,
@@ -654,20 +390,14 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87eac26c-8fcd-11eb-924d-9cd76263cbd0,species,lurida,Eulophia,,"(Sw.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634737-1,wfo-0000960038,5308351,,
 87eade0a-8fcd-11eb-924d-9cd76263cbd0,species,lutea,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,634738-1,wfo-0000960039,5311441,,
 87eafaca-8fcd-11eb-924d-9cd76263cbd0,species,lutea,Eulophia,,Blume,,1859,,"Coll. Orchid. 181 1859",,,,,,634739-1,wfo-0000960040,7934610,,
-87eb16cc-8fcd-11eb-924d-9cd76263cbd0,species,macaulayi,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
-
-
-",Q55778720,DOI:10.2307/4107556,,,634740-1,wfo-0000960041,5312050,,
+87eb16cc-8fcd-11eb-924d-9cd76263cbd0,species,macaulayi,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556",Q55778720,DOI:10.2307/4107556,,,634740-1,wfo-0000960041,5312050,,
 87eb3454-8fcd-11eb-924d-9cd76263cbd0,species,macgregorii,Eulophia,,Ames,,1914,,"Philipp. J. Sci., C 9: 12 1914",,,,,,634741-1,wfo-0000960042,5312151,,
 87eb55e2-8fcd-11eb-924d-9cd76263cbd0,species,mackaiana,Eulophia,,Lindl.,,,,"Edwards's Bot. Reg. 17: t. 1433 1831",,,,,,634742-1,wfo-0000960043,5322761,,
 87eb70cc-8fcd-11eb-924d-9cd76263cbd0,species,mackenii,Eulophia,,"Rolfe ex Hemsl.",,1892,,"Gard. Chron. III, 12: 583 1892",,,,,,,wfo-0000960044,5323740,,
 87eb8c10-8fcd-11eb-924d-9cd76263cbd0,species,mackinnonii,Eulophia,,Duthie,,1902,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 71: 40 1902",,,,,,634744-1,wfo-0000960045,5311966,,
 87eba894-8fcd-11eb-924d-9cd76263cbd0,species,macowanii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 38 1912",,,,,,634745-1,wfo-0000960046,5311925,,
 87ebe106-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634747-1,wfo-0000960048,7988890,,
-87ebc450-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Ridl.,,1886,,"J. Linn. Soc., Bot. 22: 120 1886","Ridley, H. N. (1886). On Dr. Fox’s Collection of Orchids from Madagascar, along with some obtained by the Rev. R. Baron, F.L.S., from the same island. Transactions of the Linnean Society of London: Botany, 22(142), 116–127. https://doi.org/10.1111/j.1095-8339.1886.tb00646.x
-
-
-",Q55760282,DOI:10.1111/j.1095-8339.1886.tb00646.x,,,634746-1,wfo-0000960047,5311873,,
+87ebc450-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Ridl.,,1886,,"J. Linn. Soc., Bot. 22: 120 1886","Ridley, H. N. (1886). On Dr. Fox’s Collection of Orchids from Madagascar, along with some obtained by the Rev. R. Baron, F.L.S., from the same island. Transactions of the Linnean Society of London: Botany, 22(142), 116–127. https://doi.org/10.1111/j.1095-8339.1886.tb00646.x",Q55760282,DOI:10.1111/j.1095-8339.1886.tb00646.x,,,634746-1,wfo-0000960047,5311873,,
 87ebfb82-8fcd-11eb-924d-9cd76263cbd0,species,macrantha,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 62 1897",,,,,,634748-1,wfo-0000960049,5311815,,
 87ec1860-8fcd-11eb-924d-9cd76263cbd0,species,macrobulbon,Eulophia,,"(E.C.Parish & Rchb.f.) Hook.f.",,1890,,"Fl. Brit. India 6: 7 1890",,,,7d2e5ca8-8fcd-11eb-924d-9cd76263cbd0,,634749-1,wfo-0000960050,5311771,,
 87ec355c-8fcd-11eb-924d-9cd76263cbd0,species,macrorhiza,Eulophia,,Blume,,1859,,"Coll. Orchid. 183 1859",,,,,,634750-1,wfo-0000960051,5311697,,
@@ -676,26 +406,14 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87ec87be-8fcd-11eb-924d-9cd76263cbd0,species,macrostachya,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 183 1833",,,,,,634752-1,wfo-0000960054,5311756,,
 87eca5e6-8fcd-11eb-924d-9cd76263cbd0,species,maculata,Eulophia,,"(Lindl.) Rchb.f.",,1863,,"Ann. Bot. Syst. 6: 647 1863",,,,,,634753-1,wfo-0000960055,5323741,,
 87ecc292-8fcd-11eb-924d-9cd76263cbd0,species,madagascariensis,Eulophia,,Kraenzl.,,1882,,"Abh. Naturwiss. Vereins Bremen 7: 255 1882",,,,,,634754-1,wfo-0000960056,5311392,,
-87ece0c4-8fcd-11eb-924d-9cd76263cbd0,species,maesta,Eulophia,,"(Merxm.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634755-1,wfo-0000960057,5311607,,
+87ece0c4-8fcd-11eb-924d-9cd76263cbd0,species,maesta,Eulophia,,"(Merxm.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634755-1,wfo-0000960057,5311607,,
 87ed0144-8fcd-11eb-924d-9cd76263cbd0,species,magnicristata,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 620 2001",,,,,,20000661-1,wfo-0000960058,5311646,,
 87ed1df0-8fcd-11eb-924d-9cd76263cbd0,species,mahonii,Eulophia,,"(Rolfe) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,,,634756-1,wfo-0000960059,5311666,,
-87ed3a60-8fcd-11eb-924d-9cd76263cbd0,species,malangana,Eulophia,,"(Rchb.f.) Summerh.",,1956,,"Kew Bull. 11: 232 1956","Summerhayes, V. S. (1956). African Orchids: XXIII. Kew Bulletin, 11(2), 217. https://doi.org/10.2307/4109030
-
-
-",Q55779609,DOI:10.2307/4109030,,,634757-1,wfo-0000960060,5311337,,
+87ed3a60-8fcd-11eb-924d-9cd76263cbd0,species,malangana,Eulophia,,"(Rchb.f.) Summerh.",,1956,,"Kew Bull. 11: 232 1956","Summerhayes, V. S. (1956). African Orchids: XXIII. Kew Bulletin, 11(2), 217. https://doi.org/10.2307/4109030",Q55779609,DOI:10.2307/4109030,,,634757-1,wfo-0000960060,5311337,,
 87ed75d4-8fcd-11eb-924d-9cd76263cbd0,species,manganjensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634758-1,wfo-0000960062,5311741,,
-87ed9208-8fcd-11eb-924d-9cd76263cbd0,species,mangenotiana,Eulophia,,"Bosser & Veyret",,1970,,"Adansonia n.s., 10: 216 1970","Bosser, J., & Veyret, Y. (1970). Contribution à l’étude des Orchidaceae de Madagascar. XIII. Sur un Cynorkis et un Eulophia nouveaux. Adansonia Nouvelle série, 10(2), 213-217.
-
-
-",Q58838388,,,,634759-1,wfo-0000960063,5312115,,
+87ed9208-8fcd-11eb-924d-9cd76263cbd0,species,mangenotiana,Eulophia,,"Bosser & Veyret",,1970,,"Adansonia n.s., 10: 216 1970","Bosser, J., & Veyret, Y. (1970). Contribution à l’étude des Orchidaceae de Madagascar. XIII. Sur un Cynorkis et un Eulophia nouveaux. Adansonia Nouvelle série, 10(2), 213-217.",Q58838388,,,,634759-1,wfo-0000960063,5312115,,
 87edb008-8fcd-11eb-924d-9cd76263cbd0,species,mannii,Eulophia,,"(Rchb.f.) Hook.f.",,1890,,"Fl. Brit. India 6: 4 1890",,,,,,634760-1,wfo-0000960064,5312069,,
-87edcb60-8fcd-11eb-924d-9cd76263cbd0,species,massiei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
-
-
-",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634761-1,wfo-0000960065,5311895,,
+87edcb60-8fcd-11eb-924d-9cd76263cbd0,species,massiei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634761-1,wfo-0000960065,5311895,,
 87ede7d0-8fcd-11eb-924d-9cd76263cbd0,species,massokoensis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 580 1915",,,,,,634762-1,wfo-0000960066,5312020,,
 87ee027e-8fcd-11eb-924d-9cd76263cbd0,species,maxillaris,Eulophia,,"(Lodd.) G.Don",,1850,,"Suppl. Hort. Brit. 588 1850",,,,,,,wfo-0000960067,5322762,,
 87ee1f0c-8fcd-11eb-924d-9cd76263cbd0,species,mechowii,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 23 1894",,,,,,634764-1,wfo-0000960068,5311909,,
@@ -705,98 +423,50 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87eea990-8fcd-11eb-924d-9cd76263cbd0,species,menelikii,Eulophia,,Pax,,1907,,"Bot. Jahrb. Syst. 39: 612 1907",,,,,,634768-1,wfo-0000960073,5311301,,
 87eec2cc-8fcd-11eb-924d-9cd76263cbd0,species,merrillii,Eulophia,,Ames,,1915,,"Orchidaceae 5: 104 1915",,,,,,634769-1,wfo-0000960074,5311853,,
 87eedd98-8fcd-11eb-924d-9cd76263cbd0,species,micrantha,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 184 1833",,,,,,634770-1,wfo-0000960075,5312520,,
-87eef968-8fcd-11eb-924d-9cd76263cbd0,species,microceras,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 154 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
-
-
-",Q55784833,DOI:10.2307/4117167,db63d552-8fcb-11eb-924d-9cd76263cbd0,,634771-1,wfo-0000960076,5311608,,
+87eef968-8fcd-11eb-924d-9cd76263cbd0,species,microceras,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 154 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167",Q55784833,DOI:10.2307/4117167,db63d552-8fcb-11eb-924d-9cd76263cbd0,,634771-1,wfo-0000960076,5311608,,
 87ef13bc-8fcd-11eb-924d-9cd76263cbd0,species,microdactyla,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 389 1914",,,,,,634772-1,wfo-0000960077,5311440,,
 87ef49ea-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 372 1900",,,,,,634774-1,wfo-0000960079,7373826,,
-87ef2dca-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
-
-
-",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634773-1,wfo-0000960078,5311919,,
+87ef2dca-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634773-1,wfo-0000960078,5311919,,
 87ef6506-8fcd-11eb-924d-9cd76263cbd0,species,mildbraedii,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 339 1909",,,,,,634775-1,wfo-0000960080,5323768,,
 87ef7f1e-8fcd-11eb-924d-9cd76263cbd0,species,millsonii,Eulophia,,"(Rolfe) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 446 1936",,,,db644de8-8fcb-11eb-924d-9cd76263cbd0,,634776-1,wfo-0000960081,5311352,,
 87ef98d2-8fcd-11eb-924d-9cd76263cbd0,species,milnei,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 116 1881",,,,,,634777-1,wfo-0000960082,5311439,,
 87efcf46-8fcd-11eb-924d-9cd76263cbd0,variety,norlindhii,Eulophia,milnei,"(Summerh.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 684 1992",,,,87f2d40c-8fcd-11eb-924d-9cd76263cbd0,,967485-1,wfo-0000960084,5312036,,
 87efebe8-8fcd-11eb-924d-9cd76263cbd0,species,minimiflora,Eulophia,,Kraenzl.,,1928,,"Notul. Syst. (Paris) 4: 137 1928",,,,,,634778-1,wfo-0000960085,5314462,,
 87f00772-8fcd-11eb-924d-9cd76263cbd0,species,missionis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 168 1895",,,,,,634779-1,wfo-0000960086,5311363,,
-87f02158-8fcd-11eb-924d-9cd76263cbd0,species,monantha,Eulophia,,W.W.Sm.,,1921,,"Notes Roy. Bot. Gard. Edinburgh 13: 203 1921","Smith, W. W. (1921). New orchids from Yunnan and northern Burma. Notes from the Royal Botanic Garden, Edinburgh, 13(63-64), 189-222.
-
-
-",Q102419243,,,,634780-1,wfo-0000960087,5312107,,
+87f02158-8fcd-11eb-924d-9cd76263cbd0,species,monantha,Eulophia,,W.W.Sm.,,1921,,"Notes Roy. Bot. Gard. Edinburgh 13: 203 1921","Smith, W. W. (1921). New orchids from Yunnan and northern Burma. Notes from the Royal Botanic Garden, Edinburgh, 13(63-64), 189-222.",Q102419243,,,,634780-1,wfo-0000960087,5312107,,
 87f03d96-8fcd-11eb-924d-9cd76263cbd0,species,monile,Eulophia,,Rchb.f.,,1867,,"Flora 50: 105 1867",,,,,,634781-1,wfo-0000960088,5312034,,
 54615290-8fcc-11eb-924d-9cd76263cbd0,variety,brevipetala,Eulophia,monile,"(Rolfe) Pérez-Vera",,2003,,"Orchidées Côte D'Ivoire 332 2003",,,,87c73068-8fcd-11eb-924d-9cd76263cbd0,,70027676-1,wfo-0000416225,5311836,,
-87f0570e-8fcd-11eb-924d-9cd76263cbd0,species,monoceras,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db6472d2-8fcb-11eb-924d-9cd76263cbd0,,634782-1,wfo-0000960089,5312063,,
+87f0570e-8fcd-11eb-924d-9cd76263cbd0,species,monoceras,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db6472d2-8fcb-11eb-924d-9cd76263cbd0,,634782-1,wfo-0000960089,5312063,,
 87f072b6-8fcd-11eb-924d-9cd76263cbd0,species,monophylla,Eulophia,,"(A.Rich.) S.Moore",,1877,,"Fl. Mauritius 360 1877",,,,6eea24d4-8fcc-11eb-924d-9cd76263cbd0,,634783-1,wfo-0000960090,5323736,,
 87f08c42-8fcd-11eb-924d-9cd76263cbd0,species,monotropis,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 248 1916",,,,,,634784-1,wfo-0000960091,5311971,,
-87f0ab64-8fcd-11eb-924d-9cd76263cbd0,species,monteiroi,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db649730-8fcb-11eb-924d-9cd76263cbd0,,634785-1,wfo-0000960092,5311630,,
+87f0ab64-8fcd-11eb-924d-9cd76263cbd0,species,monteiroi,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db649730-8fcb-11eb-924d-9cd76263cbd0,,634785-1,wfo-0000960092,5311630,,
 87f0c81a-8fcd-11eb-924d-9cd76263cbd0,species,monticola,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 582 1915",,,,,,634787-1,wfo-0000960093,8419353,,
 87f0e4bc-8fcd-11eb-924d-9cd76263cbd0,species,monticola,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634786-1,wfo-0000960094,5311860,,
-87f0feac-8fcd-11eb-924d-9cd76263cbd0,species,montis-elgonis,Eulophia,,Summerh.,,1932,,"Bull. Misc. Inform. Kew 1932: 509 1932","Bullock, A. A. (1932). New Species from Mount Elgon. Bulletin of Miscellaneous Information, 1932(10), 487. https://doi.org/10.2307/4113427
-
-
-",Q55782467,DOI:10.2307/4113427,,,634788-1,wfo-0000960095,5311825,,
+87f0feac-8fcd-11eb-924d-9cd76263cbd0,species,montis-elgonis,Eulophia,,Summerh.,,1932,,"Bull. Misc. Inform. Kew 1932: 509 1932","Bullock, A. A. (1932). New Species from Mount Elgon. Bulletin of Miscellaneous Information, 1932(10), 487. https://doi.org/10.2307/4113427",Q55782467,DOI:10.2307/4113427,,,634788-1,wfo-0000960095,5311825,,
 87f11b1c-8fcd-11eb-924d-9cd76263cbd0,species,moratii,Eulophia,,N.Hallé,,1977,,"in Fl. Nouv.-Caléd. 8: 246 1977",,,,,,634789-1,wfo-0000960096,5311777,,
 87f13548-8fcd-11eb-924d-9cd76263cbd0,species,mossambicensis,Eulophia,,Schelpe,,1976,,"J. S. African Bot. 42: 392 1976",,,,,,634790-1,wfo-0000960097,5311597,,
 87f15190-8fcd-11eb-924d-9cd76263cbd0,species,mucronata,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634791-1,wfo-0000960098,5312146,,
-87f16b58-8fcd-11eb-924d-9cd76263cbd0,species,multicolor,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db654fae-8fcb-11eb-924d-9cd76263cbd0,,634792-1,wfo-0000960099,5311656,,
-87f186ce-8fcd-11eb-924d-9cd76263cbd0,species,mumbwaensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
-
-
-",Q55778720,DOI:10.2307/4107556,,,634793-1,wfo-0000960100,5311619,,
+87f16b58-8fcd-11eb-924d-9cd76263cbd0,species,multicolor,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db654fae-8fcb-11eb-924d-9cd76263cbd0,,634792-1,wfo-0000960099,5311656,,
+87f186ce-8fcd-11eb-924d-9cd76263cbd0,species,mumbwaensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556",Q55778720,DOI:10.2307/4107556,,,634793-1,wfo-0000960100,5311619,,
 87f1a488-8fcd-11eb-924d-9cd76263cbd0,species,murrayana,Eulophia,,"(Gardner ex Hook.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960101,5325306,,
-87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,species,mweruensis,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 162 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,634795-1,wfo-0000960102,5311533,,
+87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,species,mweruensis,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 162 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,634795-1,wfo-0000960102,5311533,,
 87f1da70-8fcd-11eb-924d-9cd76263cbd0,species,nana,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 579 1915",,,,,,634796-1,wfo-0000960103,5311902,,
 87f22bec-8fcd-11eb-924d-9cd76263cbd0,species,natalensis,Eulophia,,Rchb.f.,,1865,,"Flora 48: 186 1865",,,,,,634797-1,wfo-0000960106,5311595,,
-87f2456e-8fcd-11eb-924d-9cd76263cbd0,species,nelsonii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
-
-
-",Q55782219,DOI:10.2307/4113249,,,634798-1,wfo-0000960107,5311399,,
+87f2456e-8fcd-11eb-924d-9cd76263cbd0,species,nelsonii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249",Q55782219,DOI:10.2307/4113249,,,634798-1,wfo-0000960107,5311399,,
 87f261fc-8fcd-11eb-924d-9cd76263cbd0,species,neopommeranica,Eulophia,,J.J.Sm.,,1909,,"Nova Guinea 8: 26 1909",,,,,,634799-1,wfo-0000960108,5311843,,
-87f2809c-8fcd-11eb-924d-9cd76263cbd0,species,nervosa,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 150 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634800-1,wfo-0000960109,5312082,,
+87f2809c-8fcd-11eb-924d-9cd76263cbd0,species,nervosa,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 150 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634800-1,wfo-0000960109,5312082,,
 87f29c58-8fcd-11eb-924d-9cd76263cbd0,species,nicobarica,Eulophia,,"N.P.Balakr. & N.G.Nair",,1976,,"Bull. Bot. Surv. India 15: 271 1976",,,,,,634801-1,wfo-0000960110,5312055,,
 87f2b9e0-8fcd-11eb-924d-9cd76263cbd0,species,nigricans,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 5 1895",,,,,,634802-1,wfo-0000960111,5311295,,
 87f2d40c-8fcd-11eb-924d-9cd76263cbd0,species,norlindhii,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 197 1937",,,,,,634803-1,wfo-0000960112,5312040,,
-87f2ee6a-8fcd-11eb-924d-9cd76263cbd0,species,novoebudae,Eulophia,,Kraenzl.,,1929,,"Bull. Soc. Bot. France 76: 301 1929","Guillaumin, A. (1929). Contribution à la flore des Nouvelles-Hébrides. Bulletin De La Société Botanique De France, 76(2), 298–303. https://doi.org/10.1080/00378941.1929.10837163
-
-
-",Q55757220,DOI:10.1080/00378941.1929.10837163,,,634804-1,wfo-0000960113,5311759,,
+87f2ee6a-8fcd-11eb-924d-9cd76263cbd0,species,novoebudae,Eulophia,,Kraenzl.,,1929,,"Bull. Soc. Bot. France 76: 301 1929","Guillaumin, A. (1929). Contribution à la flore des Nouvelles-Hébrides. Bulletin De La Société Botanique De France, 76(2), 298–303. https://doi.org/10.1080/00378941.1929.10837163",Q55757220,DOI:10.1080/00378941.1929.10837163,,,634804-1,wfo-0000960113,5311759,,
 87f308fa-8fcd-11eb-924d-9cd76263cbd0,species,nuda,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,,wfo-0000960114,5312136,,
 c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,wfo-0001088595,7809035,,
 87f32420-8fcd-11eb-924d-9cd76263cbd0,species,nutans,Eulophia,,Sond.,,1846,,"Linnaea 19: 73 1846",,,,,,634806-1,wfo-0000960115,5311390,,
 87f35b48-8fcd-11eb-924d-9cd76263cbd0,species,nuttii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 63 1897",,,,,,634807-1,wfo-0000960117,5311858,,
-87f375ce-8fcd-11eb-924d-9cd76263cbd0,species,nyasae,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
-
-
-",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634808-1,wfo-0000960118,5311816,,
-87f390d6-8fcd-11eb-924d-9cd76263cbd0,species,obcordata,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
-
-
-",Q55782426,DOI:10.2307/4113400,,,634809-1,wfo-0000960119,5311384,,
-87f3ac42-8fcd-11eb-924d-9cd76263cbd0,species,oblonga,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
-
-
-",Q55782219,DOI:10.2307/4113249,,,634810-1,wfo-0000960120,5311617,,
-87f3c808-8fcd-11eb-924d-9cd76263cbd0,species,obscura,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,634811-1,wfo-0000960121,5311743,,
+87f375ce-8fcd-11eb-924d-9cd76263cbd0,species,nyasae,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634808-1,wfo-0000960118,5311816,,
+87f390d6-8fcd-11eb-924d-9cd76263cbd0,species,obcordata,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400",Q55782426,DOI:10.2307/4113400,,,634809-1,wfo-0000960119,5311384,,
+87f3ac42-8fcd-11eb-924d-9cd76263cbd0,species,oblonga,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249",Q55782219,DOI:10.2307/4113249,,,634810-1,wfo-0000960120,5311617,,
+87f3c808-8fcd-11eb-924d-9cd76263cbd0,species,obscura,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,634811-1,wfo-0000960121,5311743,,
 87f3e4f0-8fcd-11eb-924d-9cd76263cbd0,species,obstipa,Eulophia,,"P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 534 1998",,,,,,1005717-1,wfo-0000960122,5311688,,
 87f40340-8fcd-11eb-924d-9cd76263cbd0,species,obtusa,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 3 1890",,,,,,634812-1,wfo-0000960123,5311669,,
 87f42078-8fcd-11eb-924d-9cd76263cbd0,species,ochobiensis,Eulophia,,Hayata,,1916,,"Icon. Pl. Formosan. 6: 78 1916",,,,,,634813-1,wfo-0000960124,5311699,,
@@ -805,33 +475,18 @@ c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,
 87f49242-8fcd-11eb-924d-9cd76263cbd0,species,ochyrae,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 616 2001",,,,,,20000660-1,wfo-0000960128,5312124,,
 87f4ac78-8fcd-11eb-924d-9cd76263cbd0,species,odontoglossa,Eulophia,,Rchb.f.,,1846,,"Linnaea 19: 373 1846",,,,,,634816-1,wfo-0000960129,5311354,,
 87f4c910-8fcd-11eb-924d-9cd76263cbd0,species,oedoplectron,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634817-1,wfo-0000960130,5312023,,
-87f4e512-8fcd-11eb-924d-9cd76263cbd0,species,oliveriana,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634818-1,wfo-0000960131,5312173,,
-87f500ba-8fcd-11eb-924d-9cd76263cbd0,species,orthoplectra,Eulophia,,"(Rchb.f.) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 499 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454
-
-
-",Q55782484,DOI:10.2307/4113454,,,634819-1,wfo-0000960132,5312117,,
+87f4e512-8fcd-11eb-924d-9cd76263cbd0,species,oliveriana,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634818-1,wfo-0000960131,5312173,,
+87f500ba-8fcd-11eb-924d-9cd76263cbd0,species,orthoplectra,Eulophia,,"(Rchb.f.) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 499 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454",Q55782484,DOI:10.2307/4113454,,,634819-1,wfo-0000960132,5312117,,
 87f51aa0-8fcd-11eb-924d-9cd76263cbd0,variety,rugulosa,Eulophia,orthoplectra,"(Summerh.) Geerinck",,1988,,"Fl. Rwanda 4: 575 1988",,,,880013ba-8fcd-11eb-924d-9cd76263cbd0,,954446-1,wfo-0000960133,5311425,,
 87f53634-8fcd-11eb-924d-9cd76263cbd0,variety,schweinfurthii,Eulophia,orthoplectra,"(Kraenzl.) Geerinck",,1988,,"Fl. Rwanda 4: 575 1988",,,,8802d2f8-8fcd-11eb-924d-9cd76263cbd0,,954447-1,wfo-0000960134,5311331,,
 87f5595c-8fcd-11eb-924d-9cd76263cbd0,species,ovalifolia,Eulophia,,"Ames & C.Schweinf.",,1920,,"Orchidaceae 6: 208 1920",,,,,,634820-1,wfo-0000960135,5305381,,
 87f57586-8fcd-11eb-924d-9cd76263cbd0,species,ovalis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634821-1,wfo-0000960136,5311994,,
 87f5920a-8fcd-11eb-924d-9cd76263cbd0,subspecies,bainesii,Eulophia,ovalis,"(Rolfe) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 88 1965",,,,87c370d6-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960137,7896041,,
 87f5c82e-8fcd-11eb-924d-9cd76263cbd0,variety,bainesii,Eulophia,ovalis,"(Rolfe) P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 473 1998",,,,87c370d6-8fcd-11eb-924d-9cd76263cbd0,,1005716-1,wfo-0000960139,5312002,,
-87f5fe84-8fcd-11eb-924d-9cd76263cbd0,species,ovatipetala,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
-
-
-",Q55781795,DOI:10.2307/4111720,,,634822-1,wfo-0000960141,5312001,,
-87f63b4c-8fcd-11eb-924d-9cd76263cbd0,species,paivaeana,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 151 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
-
-
-",Q55784833,DOI:10.2307/4117167,,,634823-1,wfo-0000960142,5311727,,
+87f5fe84-8fcd-11eb-924d-9cd76263cbd0,species,ovatipetala,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720",Q55781795,DOI:10.2307/4111720,,,634822-1,wfo-0000960141,5312001,,
+87f63b4c-8fcd-11eb-924d-9cd76263cbd0,species,paivaeana,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 151 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167",Q55784833,DOI:10.2307/4117167,,,634823-1,wfo-0000960142,5311727,,
 87f6933a-8fcd-11eb-924d-9cd76263cbd0,subspecies,borealis,Eulophia,paivaeana,Summerh.,,1953,,"Kew Bull. 8: 152 1953",,,,,,,wfo-0000960143,5311719,,
-87f6bfea-8fcd-11eb-924d-9cd76263cbd0,species,palmicola,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 158 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634824-1,wfo-0000960144,5313540,,
+87f6bfea-8fcd-11eb-924d-9cd76263cbd0,species,palmicola,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 158 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634824-1,wfo-0000960144,5313540,,
 87f6e01a-8fcd-11eb-924d-9cd76263cbd0,species,pandurata,Eulophia,,Rolfe,,1891,,"J. Linn. Soc., Bot. 29: 52 1891",,,,,,,wfo-0000960145,5323743,,
 87f6ffbe-8fcd-11eb-924d-9cd76263cbd0,species,panganiana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,634826-1,wfo-0000960146,5311358,,
 87f72016-8fcd-11eb-924d-9cd76263cbd0,species,paniculata,Eulophia,,Rolfe,,1905,,"Gard. Chron. 1905(2): 197 1905",,,,,,634827-1,wfo-0000960147,5323756,,
@@ -841,219 +496,117 @@ c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,
 87f7c16a-8fcd-11eb-924d-9cd76263cbd0,species,papuana,Eulophia,,"(Ridl.) J.J.Sm.",,1909,,"Nova Guinea 8: 26 1909",,,,,,634829-1,wfo-0000960152,8234945,,
 87f7e00a-8fcd-11eb-924d-9cd76263cbd0,species,paradoxa,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 68 1902",,,,,,634832-1,wfo-0000960153,5312061,,
 87f7fda6-8fcd-11eb-924d-9cd76263cbd0,variety,greatrexii,Eulophia,paradoxa,Merxm.,,1951,,"Contr. Fl. Marandellas 83 1951",,,,,,,wfo-0000960154,5312060,,
-87f81b92-8fcd-11eb-924d-9cd76263cbd0,species,parilamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634833-1,wfo-0000960155,5311307,,
+87f81b92-8fcd-11eb-924d-9cd76263cbd0,species,parilamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634833-1,wfo-0000960155,5311307,,
 87f83c8a-8fcd-11eb-924d-9cd76263cbd0,species,parviflora,Eulophia,,"(Lindl.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 149 1965",,,,,,634834-1,wfo-0000960156,5312163,,
 87f85a80-8fcd-11eb-924d-9cd76263cbd0,species,parvilabris,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 201 1837",,,,,,634835-1,wfo-0000960157,5312110,,
-87f89586-8fcd-11eb-924d-9cd76263cbd0,species,parvula,Eulophia,,"(Rendle) Summerh.",,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113
-
-
-",Q55779620,DOI:10.2307/4109113,,,634836-1,wfo-0000960158,5312043,,
-87f8f49a-8fcd-11eb-924d-9cd76263cbd0,species,pauciflora,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
-
-
-",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634837-1,wfo-0000960159,5312015,,
+87f89586-8fcd-11eb-924d-9cd76263cbd0,species,parvula,Eulophia,,"(Rendle) Summerh.",,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113",Q55779620,DOI:10.2307/4109113,,,634836-1,wfo-0000960158,5312043,,
+87f8f49a-8fcd-11eb-924d-9cd76263cbd0,species,pauciflora,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634837-1,wfo-0000960159,5312015,,
 87f9337e-8fcd-11eb-924d-9cd76263cbd0,species,paucisquamata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 125 1919",,,,,,634838-1,wfo-0000960161,5311770,,
 87f95192-8fcd-11eb-924d-9cd76263cbd0,species,pedicellata,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634839-1,wfo-0000960162,5311576,,
 87f96e70-8fcd-11eb-924d-9cd76263cbd0,species,peglerae,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 49 1912",,,,,,634840-1,wfo-0000960163,5311885,,
 54631760-8fcc-11eb-924d-9cd76263cbd0,species,pelorica,Eulophia,,"D.L.Jones & M.A.Clem.",,2004,,"Orchadian 14(8: Sci. Suppl.): ix 2004",,,,,,77062191-1,wfo-0000416234,5312108,,
 87f988d8-8fcd-11eb-924d-9cd76263cbd0,species,penduliflora,Eulophia,,Kraenzl.,,1901,,"Bot. Jahrb. Syst. 30: 288 1901",,,,,,634841-1,wfo-0000960164,5311899,,
-87f9a2fa-8fcd-11eb-924d-9cd76263cbd0,species,pentalamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634842-1,wfo-0000960165,5311956,,
+87f9a2fa-8fcd-11eb-924d-9cd76263cbd0,species,pentalamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634842-1,wfo-0000960165,5311956,,
 87f9c000-8fcd-11eb-924d-9cd76263cbd0,species,pentheri,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 339 1899",,,,,,634843-1,wfo-0000960166,5311318,,
 87f9de64-8fcd-11eb-924d-9cd76263cbd0,species,perrieri,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 174 1913",,,,,,634844-1,wfo-0000960167,5311827,,
 87f9f886-8fcd-11eb-924d-9cd76263cbd0,species,petersii,Eulophia,,"(Rchb.f.) Rchb.f.",,1865,,"Flora 48: 186 1865",,,,8b8e3fca-8fcd-11eb-924d-9cd76263cbd0,,634845-1,wfo-0000960168,5311779,,
 87fa1320-8fcd-11eb-924d-9cd76263cbd0,species,petiolata,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 175 1913",,,,,,634846-1,wfo-0000960169,5323776,,
 87fa2de2-8fcd-11eb-924d-9cd76263cbd0,species,phillipsiae,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 56 1897",,,,,,634847-1,wfo-0000960170,5311780,,
 87fa65dc-8fcd-11eb-924d-9cd76263cbd0,species,pholelana,Eulophia,,"H.Kurze & O.Kurze",,1990,,"S. African Orchid J. 21: 78 1990",,,,,,958331-1,wfo-0000960172,5311620,,
-87fa831e-8fcd-11eb-924d-9cd76263cbd0,species,pileata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 468 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
-
-
-",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634848-1,wfo-0000960173,5311587,,
+87fa831e-8fcd-11eb-924d-9cd76263cbd0,species,pileata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 468 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634848-1,wfo-0000960173,5311587,,
 87faa0d8-8fcd-11eb-924d-9cd76263cbd0,species,pillansii,Eulophia,,Bolus,,1911,,"Icon. Orchid. Austro-Afric. 2: t. 27 1911",,,,,,634849-1,wfo-0000960174,5311434,,
 87fabd48-8fcd-11eb-924d-9cd76263cbd0,species,piscicelliana,Eulophia,,"Buscal. & Muschl.",,1913,,"Bot. Jahrb. Syst. 49: 463 1913",,,,,,634850-1,wfo-0000960175,5311432,,
 87fae390-8fcd-11eb-924d-9cd76263cbd0,species,plantaginea,Eulophia,,"(Thouars) Rolfe ex Hochr.",,1908,,"Annuaire Conserv. Jard. Bot. Genève 11-12: 56 1908",,,,3f0d5212-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960176,7925287,,
 87faff88-8fcd-11eb-924d-9cd76263cbd0,species,platypetala,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634852-1,wfo-0000960177,5311437,,
-87fb1be4-8fcd-11eb-924d-9cd76263cbd0,species,plicata,Eulophia,,"(Harv. ex Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
-
-
-",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634853-1,wfo-0000960178,5311578,,
+87fb1be4-8fcd-11eb-924d-9cd76263cbd0,species,plicata,Eulophia,,"(Harv. ex Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634853-1,wfo-0000960178,5311578,,
 87fb3598-8fcd-11eb-924d-9cd76263cbd0,species,poiformis,Eulophia,,Szlach.,,1993,,"Fragm. Florist. Geobot. 38: 463 1993",,,,,,976601-1,wfo-0000960179,5311447,,
 87fb5424-8fcd-11eb-924d-9cd76263cbd0,species,poilanei,Eulophia,,Gagnep.,,1931,,"Bull. Mus. Natl. Hist. Nat. II, 3: 683 1931",,,,,,634854-1,wfo-0000960180,5311305,,
-87fb756c-8fcd-11eb-924d-9cd76263cbd0,species,porphyroglossa,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,e39e0652-8fcb-11eb-924d-9cd76263cbd0,,634855-1,wfo-0000960181,5311651,,
+87fb756c-8fcd-11eb-924d-9cd76263cbd0,species,porphyroglossa,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,e39e0652-8fcb-11eb-924d-9cd76263cbd0,,634855-1,wfo-0000960181,5311651,,
 87fbafc8-8fcd-11eb-924d-9cd76263cbd0,species,praestans,Eulophia,,Rendle,,1895,,"J. Bot. 33: 166 1895",,,,,,634856-1,wfo-0000960183,5311915,,
 87fbc97c-8fcd-11eb-924d-9cd76263cbd0,species,pratensis,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634857-1,wfo-0000960184,5312009,,
-87fbe3bc-8fcd-11eb-924d-9cd76263cbd0,species,praticola,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634858-1,wfo-0000960185,5312006,,
+87fbe3bc-8fcd-11eb-924d-9cd76263cbd0,species,praticola,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634858-1,wfo-0000960185,5312006,,
 87fbffa0-8fcd-11eb-924d-9cd76263cbd0,species,pretoriensis,Eulophia,,L.Bolus,,1933,,"Fl. Pl. South Africa 13: t. 500 1933",,,,,,634859-1,wfo-0000960186,5312004,,
 87fc1c38-8fcd-11eb-924d-9cd76263cbd0,species,preussii,Eulophia,,Kraenzl.,,1893,,"Bot. Jahrb. Syst. 17: 54 1893",,,,,,634860-1,wfo-0000960187,5311453,,
 87fc36c8-8fcd-11eb-924d-9cd76263cbd0,species,promensis,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,,wfo-0000960188,5311892,,
-87fc50ea-8fcd-11eb-924d-9cd76263cbd0,species,propinqua,Eulophia,,Hutch.,,1921,,"Bull. Misc. Inform. Kew 1921: 401 1921","Hutchinson, J. (1921). A Contribution to the Flora of Northern Nigeria. Plants Collected on the Bauchi Plateau by Mr. H. V. Lely. Bulletin of Miscellaneous Information Kew, 1921(10), 353. https://doi.org/10.2307/4113423
-
-
-",Q55782456,DOI:10.2307/4113423,,,634862-1,wfo-0000960189,5311367,,
+87fc50ea-8fcd-11eb-924d-9cd76263cbd0,species,propinqua,Eulophia,,Hutch.,,1921,,"Bull. Misc. Inform. Kew 1921: 401 1921","Hutchinson, J. (1921). A Contribution to the Flora of Northern Nigeria. Plants Collected on the Bauchi Plateau by Mr. H. V. Lely. Bulletin of Miscellaneous Information Kew, 1921(10), 353. https://doi.org/10.2307/4113423",Q55782456,DOI:10.2307/4113423,,,634862-1,wfo-0000960189,5311367,,
 87fc6d0a-8fcd-11eb-924d-9cd76263cbd0,species,protearum,Eulophia,,Rchb.f.,,1867,,"Flora 50: 104 1867",,,,,,634863-1,wfo-0000960190,5311824,,
 87fc86f0-8fcd-11eb-924d-9cd76263cbd0,species,pseudoramosa,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 175 1913",,,,,,634864-1,wfo-0000960191,5311312,,
 87fca342-8fcd-11eb-924d-9cd76263cbd0,species,pulchra,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634865-1,wfo-0000960192,5311750,,
 3715490c-8fcd-11eb-924d-9cd76263cbd0,variety,actinomorpha,Eulophia,pulchra,"W.M.Lin, Kuo Huang & T.P.Lin",,2006,,"Taiwania 51: 163 2006",,,,,,,wfo-0000808649,5312109,,
-87fcd93e-8fcd-11eb-924d-9cd76263cbd0,species,purpurascens,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
-
-
-",Q55781795,DOI:10.2307/4111720,,,634866-1,wfo-0000960194,5311406,,
-87fcf3a6-8fcd-11eb-924d-9cd76263cbd0,species,pusilla,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503
-
-
-",Q55787805,DOI:10.2307/4119503,,,634867-1,wfo-0000960195,5311449,,
+87fcd93e-8fcd-11eb-924d-9cd76263cbd0,species,purpurascens,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720",Q55781795,DOI:10.2307/4111720,,,634866-1,wfo-0000960194,5311406,,
+87fcf3a6-8fcd-11eb-924d-9cd76263cbd0,species,pusilla,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503",Q55787805,DOI:10.2307/4119503,,,634867-1,wfo-0000960195,5311449,,
 87fd1016-8fcd-11eb-924d-9cd76263cbd0,species,pyrophila,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 142 1947 publ. 1948",,,,,,,wfo-0000960196,5311604,,
 87fd2c4a-8fcd-11eb-924d-9cd76263cbd0,species,quadriloba,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 176 1913",,,,,,634869-1,wfo-0000960197,5323782,,
 87fd4842-8fcd-11eb-924d-9cd76263cbd0,species,quartiniana,Eulophia,,A.Rich.,,1850,,"Tent. Fl. Abyss. 2: 284 1850",,,,,,634871-1,wfo-0000960198,5311867,,
 87fd7dda-8fcd-11eb-924d-9cd76263cbd0,species,ramentacea,Eulophia,,Wight,,,,"Icon. Pl. Ind. Orient. 5: t. 1666 1851",,,,,,634873-1,wfo-0000960200,8108523,,
 87fd6188-8fcd-11eb-924d-9cd76263cbd0,species,ramentacea,Eulophia,,"(Roxb.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,60448330-2,wfo-0000960199,5311483,,
-87fd9a54-8fcd-11eb-924d-9cd76263cbd0,species,ramifera,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634874-1,wfo-0000960201,5311375,,
+87fd9a54-8fcd-11eb-924d-9cd76263cbd0,species,ramifera,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634874-1,wfo-0000960201,5311375,,
 87fdd028-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Hayata,,1911,,"J. Coll. Sci. Imp. Univ. Tokyo 30(1): 332 1911",,,,,,634876-1,wfo-0000960203,8242956,,
-87fdb6a6-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
-
-
-",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634875-1,wfo-0000960202,5311309,,
+87fdb6a6-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634875-1,wfo-0000960202,5311309,,
 87fe05fc-8fcd-11eb-924d-9cd76263cbd0,species,rara,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 582 1915",,,,,,634877-1,wfo-0000960205,5312081,,
-87fe21d6-8fcd-11eb-924d-9cd76263cbd0,species,recurvata,Eulophia,,G.Will.,,1980,,"Pl. Syst. Evol. 134: 70 1980","Williamson, G. (1980). Contribution to the orchid flora of South Central Africa. Plant Systematics and Evolution, 134(1-2), 53–77. https://doi.org/10.1007/bf00985031
-
-
-",Q55808601,DOI:10.1007/bf00985031,,,634878-1,wfo-0000960206,5311989,,
+87fe21d6-8fcd-11eb-924d-9cd76263cbd0,species,recurvata,Eulophia,,G.Will.,,1980,,"Pl. Syst. Evol. 134: 70 1980","Williamson, G. (1980). Contribution to the orchid flora of South Central Africa. Plant Systematics and Evolution, 134(1-2), 53–77. https://doi.org/10.1007/bf00985031",Q55808601,DOI:10.1007/bf00985031,,,634878-1,wfo-0000960206,5311989,,
 87fe3aea-8fcd-11eb-924d-9cd76263cbd0,species,regnieri,Eulophia,,"(Rchb.f.) Guillaumin",,1955,,"Bull. Mus. Natl. Hist. Nat. II, 27: 395 1955",,,,,,634879-1,wfo-0000960207,5312137,,
 87fe5476-8fcd-11eb-924d-9cd76263cbd0,species,rehmannii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 41 1912",,,,,,634880-1,wfo-0000960208,5312112,,
-87fe721c-8fcd-11eb-924d-9cd76263cbd0,species,reichenbachiana,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634881-1,wfo-0000960209,5312076,,
+87fe721c-8fcd-11eb-924d-9cd76263cbd0,species,reichenbachiana,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634881-1,wfo-0000960209,5312076,,
 87fe9030-8fcd-11eb-924d-9cd76263cbd0,species,renschiana,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 25 1894",,,,,,634882-1,wfo-0000960210,5311920,,
 c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1895,,"Consp. Fl. Afr. 5: 25 1895",,,,,,,wfo-0001088705,,,
-87feac82-8fcd-11eb-924d-9cd76263cbd0,species,reticulata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
-
-
-",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634883-1,wfo-0000960211,5311888,,
+87feac82-8fcd-11eb-924d-9cd76263cbd0,species,reticulata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634883-1,wfo-0000960211,5311888,,
 87fec938-8fcd-11eb-924d-9cd76263cbd0,species,rhodesiaca,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 248 1916",,,,,,634884-1,wfo-0000960212,5311871,,
-87fee558-8fcd-11eb-924d-9cd76263cbd0,species,richardsiae,Eulophia,,"P.J.Cribb & la Croix",,,,"Kew Bull. 52: 1001 1997","Cribb, P. J., & Croix, I. L. (1997). Two New Orchids from the Flora Zambesiaca Area. Kew Bulletin, 52(4), 1001. https://doi.org/10.2307/4117828
-
-
-",Q55785303,DOI:10.2307/4117828,,,998696-1,wfo-0000960213,5311838,,
+87fee558-8fcd-11eb-924d-9cd76263cbd0,species,richardsiae,Eulophia,,"P.J.Cribb & la Croix",,,,"Kew Bull. 52: 1001 1997","Cribb, P. J., & Croix, I. L. (1997). Two New Orchids from the Flora Zambesiaca Area. Kew Bulletin, 52(4), 1001. https://doi.org/10.2307/4117828",Q55785303,DOI:10.2307/4117828,,,998696-1,wfo-0000960213,5311838,,
 87ff01fa-8fcd-11eb-924d-9cd76263cbd0,species,rigidifolia,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 387 1914",,,,,,634885-1,wfo-0000960214,5311338,,
 87ff53f8-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 172 1913",,,,,,634887-1,wfo-0000960217,7827453,,
-87ff3756-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
-
-
-",Q55782219,DOI:10.2307/4113249,,,634886-1,wfo-0000960216,5311935,,
+87ff3756-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249",Q55782219,DOI:10.2307/4113249,,,634886-1,wfo-0000960216,5311935,,
 87ff6fd2-8fcd-11eb-924d-9cd76263cbd0,species,rolfeana,Eulophia,,Kraenzl.,,1903,,"Kunene-Sambesi Exped. 213 1903",,,,,,634888-1,wfo-0000960218,5311685,,
 87ff8936-8fcd-11eb-924d-9cd76263cbd0,species,rosea,Eulophia,,A.D.Hawkes,,1964,,"Orchid Rev. 72: 27 1964",,,,,,634889-1,wfo-0000960219,5311640,,
-87ffa47a-8fcd-11eb-924d-9cd76263cbd0,species,roseolabia,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634890-1,wfo-0000960220,5311977,,
+87ffa47a-8fcd-11eb-924d-9cd76263cbd0,species,roseolabia,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634890-1,wfo-0000960220,5311977,,
 87ffbeec-8fcd-11eb-924d-9cd76263cbd0,species,rostrata,Eulophia,,"(Hook.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,cf3f42fa-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960221,5312562,,
 87ffdae4-8fcd-11eb-924d-9cd76263cbd0,species,rouxii,Eulophia,,Kraenzl.,,1914,,"Nova Caledonia, Bot. 1: 82 1914",,,,,,634892-1,wfo-0000960222,5311752,,
 87fff524-8fcd-11eb-924d-9cd76263cbd0,species,rueppelii,Eulophia,,"(Rchb.f.) Summerh.",,1940,,"Gard. Chron. III, 107: 220 1940",,,,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,634893-1,wfo-0000960223,5311713,,
-880013ba-8fcd-11eb-924d-9cd76263cbd0,species,rugulosa,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 77 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634894-1,wfo-0000960224,5311423,,
+880013ba-8fcd-11eb-924d-9cd76263cbd0,species,rugulosa,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 77 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634894-1,wfo-0000960224,5311423,,
 88002fb2-8fcd-11eb-924d-9cd76263cbd0,species,rupestris,Eulophia,,"Wall. ex Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,,wfo-0000960225,7721170,,
 880068c4-8fcd-11eb-924d-9cd76263cbd0,species,rupestris,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 682 1847",,,,,,634895-1,wfo-0000960227,5311481,,
 88008322-8fcd-11eb-924d-9cd76263cbd0,species,rupincola,Eulophia,,Rchb.f.,,1857,,"Bonplandia (Hannover) 5: 38 1857",,,,,,634897-1,wfo-0000960228,5312166,,
 8800a0aa-8fcd-11eb-924d-9cd76263cbd0,species,rutenbergiana,Eulophia,,Kraenzl.,,1882,,"Abh. Naturwiss. Vereins Bremen 7: 255 1882",,,,,,634898-1,wfo-0000960229,5312067,,
 8800be3c-8fcd-11eb-924d-9cd76263cbd0,species,ruwenzoriensis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 166 1895",,,,,,634899-1,wfo-0000960230,5312017,,
 8800dc96-8fcd-11eb-924d-9cd76263cbd0,species,sabulosa,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 578 1915",,,,,,634900-1,wfo-0000960231,5311992,,
-8800f762-8fcd-11eb-924d-9cd76263cbd0,species,saintenoyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940396-1,wfo-0000960232,5311422,,
+8800f762-8fcd-11eb-924d-9cd76263cbd0,species,saintenoyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940396-1,wfo-0000960232,5311422,,
 88011382-8fcd-11eb-924d-9cd76263cbd0,species,sandersonii,Eulophia,,"(Rchb.f.) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,db6bd4be-8fcb-11eb-924d-9cd76263cbd0,,634901-1,wfo-0000960233,5311644,,
 88012fca-8fcd-11eb-924d-9cd76263cbd0,species,sanguinea,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 8 1890",,,,,,634902-1,wfo-0000960234,5311698,,
 88014d8e-8fcd-11eb-924d-9cd76263cbd0,species,sankeyi,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 46 1912",,,,,,634903-1,wfo-0000960235,5311965,,
 88016a4e-8fcd-11eb-924d-9cd76263cbd0,species,sankisiensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 126 1919",,,,,,634904-1,wfo-0000960236,5311872,,
 88019e38-8fcd-11eb-924d-9cd76263cbd0,species,sapinii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 103 1919",,,,,,634905-1,wfo-0000960238,5311513,,
 8801bcb0-8fcd-11eb-924d-9cd76263cbd0,species,sarticulata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,634906-1,wfo-0000960239,5311674,,
-8801d8a8-8fcd-11eb-924d-9cd76263cbd0,species,saundersiae,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248
-
-
-",Q55782215,DOI:10.2307/4113248,,,634907-1,wfo-0000960240,5312175,,
+8801d8a8-8fcd-11eb-924d-9cd76263cbd0,species,saundersiae,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248",Q55782215,DOI:10.2307/4113248,,,634907-1,wfo-0000960240,5312175,,
 8801f252-8fcd-11eb-924d-9cd76263cbd0,species,saundersiana,Eulophia,,Rchb.f.,,1866,,"Bot. Zeitung (Berlin) 24: 378 1866",,,,,,634908-1,wfo-0000960241,5323767,,
-88020dbe-8fcd-11eb-924d-9cd76263cbd0,species,saxicola,Eulophia,,"P.J.Cribb & G.Will.",,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,634909-1,wfo-0000960242,5311623,,
-88022768-8fcd-11eb-924d-9cd76263cbd0,species,sceptrum,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634910-1,wfo-0000960243,5311657,,
-88024112-8fcd-11eb-924d-9cd76263cbd0,species,schaijesii,Eulophia,,Geerinck,,1985,,"Bull. Jard. Bot. Natl. Belg. 55: 501 1985","Geerinck, D. (1985). Orchidaceae nouvelles du Zaire. Bulletin Van De Nationale Plantentuin Van België, 55(3/4), 501. https://doi.org/10.2307/3667975
-
-
-",Q55776480,DOI:10.2307/3667975,,,906058-1,wfo-0000960244,5311559,,
+88020dbe-8fcd-11eb-924d-9cd76263cbd0,species,saxicola,Eulophia,,"P.J.Cribb & G.Will.",,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,634909-1,wfo-0000960242,5311623,,
+88022768-8fcd-11eb-924d-9cd76263cbd0,species,sceptrum,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634910-1,wfo-0000960243,5311657,,
+88024112-8fcd-11eb-924d-9cd76263cbd0,species,schaijesii,Eulophia,,Geerinck,,1985,,"Bull. Jard. Bot. Natl. Belg. 55: 501 1985","Geerinck, D. (1985). Orchidaceae nouvelles du Zaire. Bulletin Van De Nationale Plantentuin Van België, 55(3/4), 501. https://doi.org/10.2307/3667975",Q55776480,DOI:10.2307/3667975,,,906058-1,wfo-0000960244,5311559,,
 88025aee-8fcd-11eb-924d-9cd76263cbd0,species,schimperiana,Eulophia,,A.Rich.,,1850,,"Tent. Fl. Abyss. 2: 283 1850",,,,,,634911-1,wfo-0000960245,5311786,,
-88027c22-8fcd-11eb-924d-9cd76263cbd0,species,schlechteri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634912-1,wfo-0000960246,5323779,,
+88027c22-8fcd-11eb-924d-9cd76263cbd0,species,schlechteri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634912-1,wfo-0000960246,5323779,,
 88029c20-8fcd-11eb-924d-9cd76263cbd0,species,schnelliae,Eulophia,,L.Bolus,,1946,,"Fl. Pl. Africa 25: t. 965 1946",,,,,,634913-1,wfo-0000960247,5311926,,
 8802d2f8-8fcd-11eb-924d-9cd76263cbd0,species,schweinfurthii,Eulophia,,Kraenzl.,,1893,,"Bot. Jahrb. Syst. 17: 54 1893",,,,,,634914-1,wfo-0000960249,5311317,,
 8802ef86-8fcd-11eb-924d-9cd76263cbd0,species,sclerophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 542 1885",,,,,,634915-1,wfo-0000960250,5323750,,
-88030dfe-8fcd-11eb-924d-9cd76263cbd0,species,scottii,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634916-1,wfo-0000960251,5311661,,
+88030dfe-8fcd-11eb-924d-9cd76263cbd0,species,scottii,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634916-1,wfo-0000960251,5311661,,
 88032bfe-8fcd-11eb-924d-9cd76263cbd0,species,scripta,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634917-1,wfo-0000960252,5308342,,
 88034c74-8fcd-11eb-924d-9cd76263cbd0,variety,concolor,Eulophia,scripta,"(Thouars) S.Moore",,1877,,"Fl. Mauritius 360 1877",,,,da681d20-8fcb-11eb-924d-9cd76263cbd0,,,wfo-0000960253,5308346,,
-8803693e-8fcd-11eb-924d-9cd76263cbd0,species,segawae,Eulophia,,Fukuy.,,1934,,"Bot. Mag. (Tokyo) 48: 437 1934","Fukuyama, N. (1934). Studia Orchidacearum Japonicarum III(Continued from Ann. Rep. Taihoku Bot. Gard. Vol. III.). Botanical Magazine, 48(571), 429–442. https://doi.org/10.15281/jplantres1887.48.429
-
-
-",Q55762706,DOI:10.15281/jplantres1887.48.429,,,634918-1,wfo-0000960254,5311905,,
-88038446-8fcd-11eb-924d-9cd76263cbd0,species,seleensis,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634919-1,wfo-0000960255,5311982,,
+8803693e-8fcd-11eb-924d-9cd76263cbd0,species,segawae,Eulophia,,Fukuy.,,1934,,"Bot. Mag. (Tokyo) 48: 437 1934","Fukuyama, N. (1934). Studia Orchidacearum Japonicarum III(Continued from Ann. Rep. Taihoku Bot. Gard. Vol. III.). Botanical Magazine, 48(571), 429–442. https://doi.org/10.15281/jplantres1887.48.429",Q55762706,DOI:10.15281/jplantres1887.48.429,,,634918-1,wfo-0000960254,5311905,,
+88038446-8fcd-11eb-924d-9cd76263cbd0,species,seleensis,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634919-1,wfo-0000960255,5311982,,
 8803a1ec-8fcd-11eb-924d-9cd76263cbd0,variety,kisanfuensis,Eulophia,seleensis,"(De Wild.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 686 1992",,,,,,967487-1,wfo-0000960256,5311988,,
 8803bc72-8fcd-11eb-924d-9cd76263cbd0,variety,tenuiscapa,Eulophia,seleensis,"(Schltr.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 685 1992",,,,880a7026-8fcd-11eb-924d-9cd76263cbd0,,967486-1,wfo-0000960257,5311985,,
 8803d90a-8fcd-11eb-924d-9cd76263cbd0,species,serrata,Eulophia,,P.J.Cribb,,1989,,"in Fl. Trop. E. Afr. Orchid.(3): 442 1989",,,,,,941226-1,wfo-0000960258,5311492,,
-880410e6-8fcd-11eb-924d-9cd76263cbd0,species,seychellarum,Eulophia,,"Rolfe ex Summerh.",,1928,,"Bull. Misc. Inform. Kew 1928: 393 1928","Summerhayes, V. S. (1928). New Plants from the Seychelles. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1928(10), 388. https://doi.org/10.2307/4107106
-
-
-",Q55778525,DOI:10.2307/4107106,,,634920-1,wfo-0000960260,5323734,,
+880410e6-8fcd-11eb-924d-9cd76263cbd0,species,seychellarum,Eulophia,,"Rolfe ex Summerh.",,1928,,"Bull. Misc. Inform. Kew 1928: 393 1928","Summerhayes, V. S. (1928). New Plants from the Seychelles. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1928(10), 388. https://doi.org/10.2307/4107106",Q55778525,DOI:10.2307/4107106,,,634920-1,wfo-0000960260,5323734,,
 88042b26-8fcd-11eb-924d-9cd76263cbd0,species,shupangae,Eulophia,,"(Rchb.f.) Kraenzl.",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,7d30d7ee-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960261,5311372,,
-880447c8-8fcd-11eb-924d-9cd76263cbd0,species,siamensis,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477
-
-
-",Q55778673,DOI:10.2307/4107477,,,634922-1,wfo-0000960262,5311760,,
+880447c8-8fcd-11eb-924d-9cd76263cbd0,species,siamensis,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477",Q55778673,DOI:10.2307/4107477,,,634922-1,wfo-0000960262,5311760,,
 88046492-8fcd-11eb-924d-9cd76263cbd0,species,silvatica,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 586 1915",,,,,,634923-1,wfo-0000960263,5311755,,
 88047f18-8fcd-11eb-924d-9cd76263cbd0,species,sinensis,Eulophia,,Miq.,,1861,,"J. Bot. Néerl. 1: 91 1861",,,,,,634924-1,wfo-0000960264,5312162,,
 8804991c-8fcd-11eb-924d-9cd76263cbd0,species,smithii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 54 1897",,,,,,634925-1,wfo-0000960265,5311782,,
 8804b5d2-8fcd-11eb-924d-9cd76263cbd0,species,sooi,Eulophia,,"Chun & Tang ex S.C.Chen",,1999,,"in Fl. Reipubl. Popul. Sin. 18: 412 1999",,,,,,1019125-1,wfo-0000960266,5311618,,
 8804d22e-8fcd-11eb-924d-9cd76263cbd0,species,sordida,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 67 1902",,,,,,634926-1,wfo-0000960267,5311585,,
-8804ee26-8fcd-11eb-924d-9cd76263cbd0,species,spathulifera,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 157 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
-
-
-",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634927-1,wfo-0000960268,5323752,,
+8804ee26-8fcd-11eb-924d-9cd76263cbd0,species,spathulifera,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 157 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634927-1,wfo-0000960268,5323752,,
 88054416-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 63 1897",,,,,,634929-1,wfo-0000960271,8213600,,
-880509a6-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,"(R.Br.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634928-1,wfo-0000960269,5311380,,
+880509a6-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,"(R.Br.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634928-1,wfo-0000960269,5311380,,
 364715fa-8fcd-11eb-924d-9cd76263cbd0,variety,culveri,Eulophia,speciosa,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 10 1895",,,,,,,wfo-0000807056,5311499,,
-88056144-8fcd-11eb-924d-9cd76263cbd0,species,speciosissima,Eulophia,,Butzin,,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634930-1,wfo-0000960272,5311378,,
+88056144-8fcd-11eb-924d-9cd76263cbd0,species,speciosissima,Eulophia,,Butzin,,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634930-1,wfo-0000960272,5311378,,
 88059b3c-8fcd-11eb-924d-9cd76263cbd0,species,spectabilis,Eulophia,,"(Dennst.) Suresh",,1988,,"Interpret. Van Rheede's Hort. Malab. 300 1988",,,,cbb0ea5e-8fcc-11eb-924d-9cd76263cbd0,,945130-1,wfo-0000960273,5312126,,
 8805fcee-8fcd-11eb-924d-9cd76263cbd0,species,sphaerocarpa,Eulophia,,Sond.,,1846,,"Linnaea 19: 74 1846",,,,,,634931-1,wfo-0000960274,5312513,,
 880644ba-8fcd-11eb-924d-9cd76263cbd0,species,squalida,Eulophia,,Lindl.,,1841,,"Edwards's Bot. Reg. 27(Misc.): 77 1841",,,,,,634932-1,wfo-0000960275,5312131,,
@@ -1061,47 +614,26 @@ c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.
 88067f70-8fcd-11eb-924d-9cd76263cbd0,species,stenantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 27 1895",,,,,,634934-1,wfo-0000960277,5311558,,
 88069c4e-8fcd-11eb-924d-9cd76263cbd0,species,stenochila,Eulophia,,"(Lodd.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960278,5310368,,
 8806b95e-8fcd-11eb-924d-9cd76263cbd0,species,stenopetala,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 26 1858",,,,,,634936-1,wfo-0000960279,5311969,,
-8806d61e-8fcd-11eb-924d-9cd76263cbd0,species,stenophylla,Eulophia,,Summerh.,,1949,,"Kew Bull. 4: 434 1949","Summerhayes, V. S. (1949). African Orchids: XIX. Kew Bulletin, 4(3), 427. https://doi.org/10.2307/4109203
-
-
-",Q55779639,DOI:10.2307/4109203,,,634937-1,wfo-0000960280,5311710,,
-88070f9e-8fcd-11eb-924d-9cd76263cbd0,species,stenoplectra,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 81 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
-
-
-",Q55785005,DOI:10.2307/4117623,,,634938-1,wfo-0000960282,5311857,,
+8806d61e-8fcd-11eb-924d-9cd76263cbd0,species,stenophylla,Eulophia,,Summerh.,,1949,,"Kew Bull. 4: 434 1949","Summerhayes, V. S. (1949). African Orchids: XIX. Kew Bulletin, 4(3), 427. https://doi.org/10.2307/4109203",Q55779639,DOI:10.2307/4109203,,,634937-1,wfo-0000960280,5311710,,
+88070f9e-8fcd-11eb-924d-9cd76263cbd0,species,stenoplectra,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 81 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623",Q55785005,DOI:10.2307/4117623,,,634938-1,wfo-0000960282,5311857,,
 88072c22-8fcd-11eb-924d-9cd76263cbd0,species,stewartiae,Eulophia,,Rolfe,,1916,,"Bull. Misc. Inform. Kew 1916: 78 1916",,,,,,,wfo-0000960283,5312114,,
 8807477a-8fcd-11eb-924d-9cd76263cbd0,species,stolziana,Eulophia,,"(Kraenzl.) Engl.",,1908,,"Veg. Erde 9(II): 444 1908",,,,7d311222-8fcd-11eb-924d-9cd76263cbd0,,634940-1,wfo-0000960284,5312100,,
 880761d8-8fcd-11eb-924d-9cd76263cbd0,species,stolzii,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 577 1915",,,,,,634941-1,wfo-0000960285,5311543,,
 88077ec0-8fcd-11eb-924d-9cd76263cbd0,species,streptopetala,Eulophia,,Lindl.,,,,"Bot. Reg. 12: t. 1002 1826",,,,,,634942-1,wfo-0000960286,5311707,,
-88079982-8fcd-11eb-924d-9cd76263cbd0,variety,rueppelii,Eulophia,streptopetala,"(Rchb.f.) P.J.Cribb",,1979,,"Kew Bull. 33: 676 1979","Cribb, P. J. (1979). The Orchids of Arabia. Kew Bulletin, 33(4), 651. https://doi.org/10.2307/4109808
-
-
-",Q55779796,DOI:10.2307/4109808,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,887512-1,wfo-0000960287,,,
+88079982-8fcd-11eb-924d-9cd76263cbd0,variety,rueppelii,Eulophia,streptopetala,"(Rchb.f.) P.J.Cribb",,1979,,"Kew Bull. 33: 676 1979","Cribb, P. J. (1979). The Orchids of Arabia. Kew Bulletin, 33(4), 651. https://doi.org/10.2307/4109808",Q55779796,DOI:10.2307/4109808,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,887512-1,wfo-0000960287,,,
 8807b412-8fcd-11eb-924d-9cd76263cbd0,variety,stenophylla,Eulophia,streptopetala,"(Summerh.) P.J.Cribb",,1989,,"in Fl. Trop. E. Afr. Orchid.(3): 471 1989",,,,,,955895-1,wfo-0000960288,5311708,,
 8807ebb2-8fcd-11eb-924d-9cd76263cbd0,species,striata,Eulophia,,Rolfe,,1891,,"J. Linn. Soc., Bot. 29: 53 1891",,,,,,,wfo-0000960290,5311751,,
 88080750-8fcd-11eb-924d-9cd76263cbd0,species,stricta,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 51 1897",,,,,,634945-1,wfo-0000960291,5311491,,
 88084116-8fcd-11eb-924d-9cd76263cbd0,species,stricta,Eulophia,,"(C.Presl) Ames",,1915,,"Orchidaceae 5: 103 1915",,,,,,634946-1,wfo-0000960293,7390713,,
-88085e76-8fcd-11eb-924d-9cd76263cbd0,species,stuhlmannii,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634947-1,wfo-0000960294,5311725,,
+88085e76-8fcd-11eb-924d-9cd76263cbd0,species,stuhlmannii,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634947-1,wfo-0000960294,5311725,,
 880879a6-8fcd-11eb-924d-9cd76263cbd0,species,stylites,Eulophia,,"(Rchb.f.) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,db6dffdc-8fcb-11eb-924d-9cd76263cbd0,,634948-1,wfo-0000960295,5311633,,
 88089418-8fcd-11eb-924d-9cd76263cbd0,species,subintegra,Eulophia,,Rolfe,,1912,,"Fl. Cap. 6(3): 41 1912",,,,,,,wfo-0000960296,5312012,,
 8808b0ec-8fcd-11eb-924d-9cd76263cbd0,species,subsaprophytica,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 576 1915",,,,,,634950-1,wfo-0000960297,5312116,,
 8808d040-8fcd-11eb-924d-9cd76263cbd0,species,subulata,Eulophia,,Rendle,,1895,,"J. Bot. 33: 167 1895",,,,,,634951-1,wfo-0000960298,5312078,,
 8808ece2-8fcd-11eb-924d-9cd76263cbd0,species,sumatrana,Eulophia,,Blume,,1859,,"Coll. Orchid. 183 1859",,,,,,634952-1,wfo-0000960299,5312147,,
-88090844-8fcd-11eb-924d-9cd76263cbd0,species,suzannae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940397-1,wfo-0000960300,5311993,,
-880921bc-8fcd-11eb-924d-9cd76263cbd0,species,swynnertonii,Eulophia,,Rendle,,1911,,"J. Linn. Soc., Bot. 40: 207 1911","Rendle, A. B., Baker, E. G., Moore, S., & Gepp, A. (1911). A Contribution to our Knowledge of the Flora of Gazaland: being an Account of Collections made by C. F. M. Swynnerton Esq., F.L.S. Transactions of the Linnean Society of London: Botany, 40(275), 1–245. https://doi.org/10.1111/j.1095-8339.1911.tb00869.x
-
-
-",Q55760482,DOI:10.1111/j.1095-8339.1911.tb00869.x,,,634953-1,wfo-0000960301,5312164,,
-88093ddc-8fcd-11eb-924d-9cd76263cbd0,species,sylviae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940398-1,wfo-0000960302,5311962,,
+88090844-8fcd-11eb-924d-9cd76263cbd0,species,suzannae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940397-1,wfo-0000960300,5311993,,
+880921bc-8fcd-11eb-924d-9cd76263cbd0,species,swynnertonii,Eulophia,,Rendle,,1911,,"J. Linn. Soc., Bot. 40: 207 1911","Rendle, A. B., Baker, E. G., Moore, S., & Gepp, A. (1911). A Contribution to our Knowledge of the Flora of Gazaland: being an Account of Collections made by C. F. M. Swynnerton Esq., F.L.S. Transactions of the Linnean Society of London: Botany, 40(275), 1–245. https://doi.org/10.1111/j.1095-8339.1911.tb00869.x",Q55760482,DOI:10.1111/j.1095-8339.1911.tb00869.x,,,634953-1,wfo-0000960301,5312164,,
+88093ddc-8fcd-11eb-924d-9cd76263cbd0,species,sylviae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940398-1,wfo-0000960302,5311962,,
 88097612-8fcd-11eb-924d-9cd76263cbd0,species,tabularis,Eulophia,,"(L.f.) Bolus",,1888,,"Trans. S. African Philos. Soc. 5(1): 108 1888",,,,,,634954-1,wfo-0000960304,5311882,,
 88099160-8fcd-11eb-924d-9cd76263cbd0,species,tainioides,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 339 1899",,,,,,634955-1,wfo-0000960305,5323730,,
 8809aed4-8fcd-11eb-924d-9cd76263cbd0,species,taitensis,Eulophia,,"Pfennig & P.J.Cribb",,1977,,"Orchidee (Hamburg) 28: 215 1977",,,,,,634956-1,wfo-0000960306,5311837,,
@@ -1110,66 +642,33 @@ c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.
 8809e7aa-8fcd-11eb-924d-9cd76263cbd0,species,tanganyikae,Eulophia,,Kraenzl.,,1900,,"Bull. Soc. Roy. Bot. Belgique 38: 216 1900",,,,,,,wfo-0000960308,5312045,,
 880a02e4-8fcd-11eb-924d-9cd76263cbd0,species,tanganyikensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 59 1897",,,,,,634959-1,wfo-0000960309,5311746,,
 880a1f86-8fcd-11eb-924d-9cd76263cbd0,species,tayloriana,Eulophia,,"(Rendle) Rolfe",,1897,,"Fl. Trop. Afr. 7: 69 1897",,,,,,634960-1,wfo-0000960310,5307902,,
-880a39e4-8fcd-11eb-924d-9cd76263cbd0,species,taylorii,Eulophia,,"(Ridl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,db6e3ea2-8fcb-11eb-924d-9cd76263cbd0,,634961-1,wfo-0000960311,5311606,,
+880a39e4-8fcd-11eb-924d-9cd76263cbd0,species,taylorii,Eulophia,,"(Ridl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,db6e3ea2-8fcb-11eb-924d-9cd76263cbd0,,634961-1,wfo-0000960311,5311606,,
 880a5384-8fcd-11eb-924d-9cd76263cbd0,species,tenella,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 681 1847",,,,,,634962-1,wfo-0000960312,5311592,,
 880a7026-8fcd-11eb-924d-9cd76263cbd0,species,tenuiscapa,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 219 1916",,,,,,634963-1,wfo-0000960313,5311987,,
 880aa640-8fcd-11eb-924d-9cd76263cbd0,species,thollonii,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 652 2001",,,,,,20000662-1,wfo-0000960315,5311442,,
 880ac09e-8fcd-11eb-924d-9cd76263cbd0,species,thomsonii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 66 1897",,,,,,634964-1,wfo-0000960316,5311457,,
-880adb88-8fcd-11eb-924d-9cd76263cbd0,species,thunbergii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
-
-
-",Q55782219,DOI:10.2307/4113249,,,634965-1,wfo-0000960317,5311996,,
+880adb88-8fcd-11eb-924d-9cd76263cbd0,species,thunbergii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249",Q55782219,DOI:10.2307/4113249,,,634965-1,wfo-0000960317,5311996,,
 880af85c-8fcd-11eb-924d-9cd76263cbd0,species,tisserantii,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 654 2001",,,,,,20000663-1,wfo-0000960318,5312039,,
 880b35ba-8fcd-11eb-924d-9cd76263cbd0,species,toyoshimae,Eulophia,,Nakai,,1920,,"Bot. Mag. (Tokyo) 34: 145 1920",,,,,,634966-1,wfo-0000960319,5311306,,
-880b5ca2-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
-
-
-",Q100705852,,,,634968-1,wfo-0000960320,5311411,,
-880b7f48-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
-
-
-",Q55781795,DOI:10.2307/4111720,,,634967-1,wfo-0000960321,7634819,,
+880b5ca2-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.",Q100705852,,,,634968-1,wfo-0000960320,5311411,,
+880b7f48-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720",Q55781795,DOI:10.2307/4111720,,,634967-1,wfo-0000960321,7634819,,
 880b9dac-8fcd-11eb-924d-9cd76263cbd0,variety,thorncroftii,Eulophia,transvaalensis,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924",,,,,,,wfo-0000960322,5312007,,
 880bbbb6-8fcd-11eb-924d-9cd76263cbd0,species,triceras,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 578 1915",,,,,,634969-1,wfo-0000960323,5311545,,
 880bd826-8fcd-11eb-924d-9cd76263cbd0,species,tricristata,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 218 1903",,,,,,634970-1,wfo-0000960324,5311990,,
 880c4928-8fcd-11eb-924d-9cd76263cbd0,species,trilamellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 127 1919",,,,,,634971-1,wfo-0000960328,5311879,,
-880c6642-8fcd-11eb-924d-9cd76263cbd0,species,triloba,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 81 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
-
-
-",Q55782426,DOI:10.2307/4113400,,,634972-1,wfo-0000960329,5311395,,
+880c6642-8fcd-11eb-924d-9cd76263cbd0,species,triloba,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 81 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400",Q55782426,DOI:10.2307/4113400,,,634972-1,wfo-0000960329,5311395,,
 880c8212-8fcd-11eb-924d-9cd76263cbd0,species,tristis,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634973-1,wfo-0000960330,5312515,,
-880ca148-8fcd-11eb-924d-9cd76263cbd0,species,tuberculata,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
-
-
-",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634974-1,wfo-0000960331,5311761,,
+880ca148-8fcd-11eb-924d-9cd76263cbd0,species,tuberculata,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634974-1,wfo-0000960331,5311761,,
 880cbebc-8fcd-11eb-924d-9cd76263cbd0,species,tuberifera,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,634975-1,wfo-0000960332,5311344,,
 c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,,wfo-0001088702,7472447,,
-880cdcd0-8fcd-11eb-924d-9cd76263cbd0,species,turkestanica,Eulophia,,"(Litv.) Schltr.",,1913,,"Repert. Spec. Nov. Regni Veg. 12: 374 1913","Schlechter, R. (1913). LXVI. Eulophia turcestanica (Litw.) Schltr., nov. comb. Feddes Repertorium Specierum Novarum Regni Vegetabilis, 12(22-24), 374. https://doi.org/10.1002/fedr.19130122209
-
-
-",Q55752861,DOI:10.1002/fedr.19130122209,,,634976-1,wfo-0000960333,5311484,,
-880cf6de-8fcd-11eb-924d-9cd76263cbd0,species,ucbii,Eulophia,,"Malhotra & Balodi",,1984,,"Bull. Bot. Surv. India 26: 92 1984 publ. 1985","Malhotra, C. L., & Balodi, B. (1984). A New Species of Eulophia R. Br. (orchidaceae) from Gori Valley. Bulletin of the Botanical Survey of India, 26(1-2), 92-94. https://doi.org/10.20324/nelumbo/v26/1984/74853
-
-
-",Q101073683,DOI:10.20324/nelumbo/v26/1984/74853,,,929052-1,wfo-0000960334,5312160,,
-880d138a-8fcd-11eb-924d-9cd76263cbd0,species,ugandae,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028
-
-
-",Q55783828,DOI:10.2307/4115028,,,634977-1,wfo-0000960335,5323758,,
+880cdcd0-8fcd-11eb-924d-9cd76263cbd0,species,turkestanica,Eulophia,,"(Litv.) Schltr.",,1913,,"Repert. Spec. Nov. Regni Veg. 12: 374 1913","Schlechter, R. (1913). LXVI. Eulophia turcestanica (Litw.) Schltr., nov. comb. Feddes Repertorium Specierum Novarum Regni Vegetabilis, 12(22-24), 374. https://doi.org/10.1002/fedr.19130122209",Q55752861,DOI:10.1002/fedr.19130122209,,,634976-1,wfo-0000960333,5311484,,
+880cf6de-8fcd-11eb-924d-9cd76263cbd0,species,ucbii,Eulophia,,"Malhotra & Balodi",,1984,,"Bull. Bot. Surv. India 26: 92 1984 publ. 1985","Malhotra, C. L., & Balodi, B. (1984). A New Species of Eulophia R. Br. (orchidaceae) from Gori Valley. Bulletin of the Botanical Survey of India, 26(1-2), 92-94. https://doi.org/10.20324/nelumbo/v26/1984/74853",Q101073683,DOI:10.20324/nelumbo/v26/1984/74853,,,929052-1,wfo-0000960334,5312160,,
+880d138a-8fcd-11eb-924d-9cd76263cbd0,species,ugandae,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028",Q55783828,DOI:10.2307/4115028,,,634977-1,wfo-0000960335,5323758,,
 880d2fa0-8fcd-11eb-924d-9cd76263cbd0,species,ukingensis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 579 1915",,,,,,634978-1,wfo-0000960336,5311586,,
 880d48f0-8fcd-11eb-924d-9cd76263cbd0,species,undulata,Eulophia,,Rolfe,,1905,,"Gard. Chron. III, 38: 198 1905",,,,,,,wfo-0000960337,5311435,,
 880d81ee-8fcd-11eb-924d-9cd76263cbd0,species,ustulata,Eulophia,,"(Bolus) Bolus",,1888,,"Trans. S. African Philos. Soc. 5(1): 110 1888",,,,,,634980-1,wfo-0000960339,5312519,,
-880d9fbc-8fcd-11eb-924d-9cd76263cbd0,species,vaginata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 467 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
-
-
-",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634981-1,wfo-0000960340,5311391,,
-880dbcc2-8fcd-11eb-924d-9cd76263cbd0,species,vandervekeniana,Eulophia,,Geerinck,,1977,,"Bull. Jard. Bot. Natl. Belg. 47: 484 1977","Geerinck, D. (1977). Deux nouvelles especes d’ Orchidaceae pour le Rwanda et le Burundi. Bulletin Van De Nationale Plantentuin Van België, 47(3/4), 484. https://doi.org/10.2307/3667915
-
-
-",Q55776470,DOI:10.2307/3667915,,,634982-1,wfo-0000960341,5307900,,
+880d9fbc-8fcd-11eb-924d-9cd76263cbd0,species,vaginata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 467 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634981-1,wfo-0000960340,5311391,,
+880dbcc2-8fcd-11eb-924d-9cd76263cbd0,species,vandervekeniana,Eulophia,,Geerinck,,1977,,"Bull. Jard. Bot. Natl. Belg. 47: 484 1977","Geerinck, D. (1977). Deux nouvelles especes d’ Orchidaceae pour le Rwanda et le Burundi. Bulletin Van De Nationale Plantentuin Van België, 47(3/4), 484. https://doi.org/10.2307/3667915",Q55776470,DOI:10.2307/3667915,,,634982-1,wfo-0000960341,5307900,,
 880dd64e-8fcd-11eb-924d-9cd76263cbd0,species,vanoverberghii,Eulophia,,Ames,,1912,,"Philipp. J. Sci., C 7: 13 1912",,,,,,634983-1,wfo-0000960342,5311851,,
 880df03e-8fcd-11eb-924d-9cd76263cbd0,species,variopicta,Eulophia,,Chiov.,,1911,,"Ann. Bot. (Rome) 9: 135 1911",,,,,,634984-1,wfo-0000960343,5312032,,
 880e0cea-8fcd-11eb-924d-9cd76263cbd0,species,venosa,Eulophia,,"(F.Muell.) Rchb.f. ex Benth.",,1873,,"Fl. Austral. 6: 300 1873",,,,,,634985-1,wfo-0000960344,5312085,,
@@ -1178,10 +677,7 @@ c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,
 880e4dcc-8fcd-11eb-924d-9cd76263cbd0,species,venusta,Eulophia,,Schltr.,,1919,,"Repert. Spec. Nov. Regni Veg. Beih. 4: 72 1919",,,,,,634987-1,wfo-0000960346,5312033,,
 880e6b86-8fcd-11eb-924d-9cd76263cbd0,species,vera,Eulophia,,Royle,,1839,,"Ill. Bot. Himal. Mts. 366 1839",,,,,,,wfo-0000960347,5311472,,
 880e9fa2-8fcd-11eb-924d-9cd76263cbd0,species,vermiculata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 107 1919",,,,,,634989-1,wfo-0000960348,5311325,,
-880ef0ba-8fcd-11eb-924d-9cd76263cbd0,species,verrucosa,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,634990-1,wfo-0000960350,5311763,,
+880ef0ba-8fcd-11eb-924d-9cd76263cbd0,species,verrucosa,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,634990-1,wfo-0000960350,5311763,,
 880f1a18-8fcd-11eb-924d-9cd76263cbd0,species,versicolor,Eulophia,,"Frapp. ex Cordem.",,1895,,"Fl. Réunion 221 1895",,,,,,634991-1,wfo-0000960351,5311878,,
 880f3d2c-8fcd-11eb-924d-9cd76263cbd0,species,versteegii,Eulophia,,J.J.Sm.,,1908,,"Bull. Dép. Agric. Indes Néerl. 19: 24 1908",,,,,,634992-1,wfo-0000960352,5311856,,
 880f596a-8fcd-11eb-924d-9cd76263cbd0,species,violacea,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 683 1847",,,,,,634993-1,wfo-0000960353,5311383,,
@@ -1190,45 +686,24 @@ c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,
 880f8eee-8fcd-11eb-924d-9cd76263cbd0,species,virens,Eulophia,,"Stocks ex Lindl.",,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634995-1,wfo-0000960355,7901487,,
 880fc54e-8fcd-11eb-924d-9cd76263cbd0,species,viridiflora,Eulophia,,Steud.,,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960357,5311556,,
 880fdf16-8fcd-11eb-924d-9cd76263cbd0,species,virilis,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,635000-1,wfo-0000960358,5308350,,
-880ffa0a-8fcd-11eb-924d-9cd76263cbd0,species,vleminckxiana,Eulophia,,"Geerinck & Schaijes",,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 188 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
-
-
-",Q55776633,DOI:10.2307/3668340,,,940399-1,wfo-0000960359,5311403,,
-881031dc-8fcd-11eb-924d-9cd76263cbd0,species,volkensii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,635001-1,wfo-0000960361,5311520,,
-88105004-8fcd-11eb-924d-9cd76263cbd0,species,wakefieldii,Eulophia,,"(Rchb.f. & S.Moore) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 500 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454
-
-
-",Q55782484,DOI:10.2307/4113454,db703680-8fcb-11eb-924d-9cd76263cbd0,,635002-1,wfo-0000960362,5311508,,
+880ffa0a-8fcd-11eb-924d-9cd76263cbd0,species,vleminckxiana,Eulophia,,"Geerinck & Schaijes",,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 188 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340",Q55776633,DOI:10.2307/3668340,,,940399-1,wfo-0000960359,5311403,,
+881031dc-8fcd-11eb-924d-9cd76263cbd0,species,volkensii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,635001-1,wfo-0000960361,5311520,,
+88105004-8fcd-11eb-924d-9cd76263cbd0,species,wakefieldii,Eulophia,,"(Rchb.f. & S.Moore) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 500 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454",Q55782484,DOI:10.2307/4113454,db703680-8fcb-11eb-924d-9cd76263cbd0,,635002-1,wfo-0000960362,5311508,,
 88106d32-8fcd-11eb-924d-9cd76263cbd0,species,walleri,Eulophia,,"(Rchb.f.) Kraenzl.",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,,wfo-0000960363,5311429,,
 88109406-8fcd-11eb-924d-9cd76263cbd0,species,warburgiana,Eulophia,,Kraenzl.,,1893,,"Xenia Orchid. 3: 115 1893",,,,,,,wfo-0000960364,5543230,,
 8810b3f0-8fcd-11eb-924d-9cd76263cbd0,species,warburgii,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 214 1903",,,,,,635005-1,wfo-0000960365,5311340,,
 8810cde0-8fcd-11eb-924d-9cd76263cbd0,species,warneckeana,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 67 1902",,,,,,635006-1,wfo-0000960366,5311443,,
-8810ea50-8fcd-11eb-924d-9cd76263cbd0,species,watkinsonii,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028
-
-
-",Q55783828,DOI:10.2307/4115028,,,635007-1,wfo-0000960367,5311410,,
+8810ea50-8fcd-11eb-924d-9cd76263cbd0,species,watkinsonii,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028",Q55783828,DOI:10.2307/4115028,,,635007-1,wfo-0000960367,5311410,,
 881120f6-8fcd-11eb-924d-9cd76263cbd0,species,welwitschii,Eulophia,,"(Rchb.f.) Rolfe",,1889,,"Bol. Soc. Brot. 7: 236 1889",,,,,,635008-1,wfo-0000960369,5311917,,
 881106f2-8fcd-11eb-924d-9cd76263cbd0,species,welwitschii,Eulophia,,Hook.f.,,,,"Bot. Mag. 119: t. 7330 1893",,,,,,635009-1,wfo-0000960368,7965576,,
 309c373e-8fcd-11eb-924d-9cd76263cbd0,subspecies,aurantiaca,Eulophia,welwitschii,"(Rolfe) Geerinck",,2004,,"Taxonomania 14: 12 2004",,,,87c2ca1e-8fcd-11eb-924d-9cd76263cbd0,,77065537-1,wfo-0000795140,5311467,,
 309c53a4-8fcd-11eb-924d-9cd76263cbd0,subspecies,carsonii,Eulophia,welwitschii,"(Rolfe) Geerinck",,2005,,"Taxonomania 16: 9 2005",,,,,,77069398-1,wfo-0000795141,5311316,,
 88113a1e-8fcd-11eb-924d-9cd76263cbd0,species,wendlandiana,Eulophia,,Kraenzl.,,1897,,"Gard. Chron. III, 22: 262 1897",,,,,,,wfo-0000960370,5312048,,
-881172a4-8fcd-11eb-924d-9cd76263cbd0,species,williamsonii,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 166 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
-
-
-",Q43230546,DOI:10.2307/4117264,,,635011-1,wfo-0000960372,5311686,,
-88118bfe-8fcd-11eb-924d-9cd76263cbd0,species,wilsonii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
-
-
-",Q105743545,,,,635012-1,wfo-0000960373,5311529,,
+881172a4-8fcd-11eb-924d-9cd76263cbd0,species,williamsonii,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 166 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264",Q43230546,DOI:10.2307/4117264,,,635011-1,wfo-0000960372,5311686,,
+88118bfe-8fcd-11eb-924d-9cd76263cbd0,species,wilsonii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.",Q105743545,,,,635012-1,wfo-0000960373,5311529,,
 8811a7ce-8fcd-11eb-924d-9cd76263cbd0,species,woodfordii,Eulophia,,"(Sims) Rolfe",,1897,,"Fl. Trop. Afr. 7: 68 1897",,,,7d3bbae2-8fcd-11eb-924d-9cd76263cbd0,,635013-1,wfo-0000960374,5311799,,
 8811c83a-8fcd-11eb-924d-9cd76263cbd0,species,woodii,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 5 1895",,,,,,635014-1,wfo-0000960375,5311918,,
-8811e5fe-8fcd-11eb-924d-9cd76263cbd0,species,yunnanensis,Eulophia,,Rolfe,,1903,,"J. Linn. Soc., Bot. 36: 29 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x
-
-
-",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,635015-1,wfo-0000960376,5305652,,
+8811e5fe-8fcd-11eb-924d-9cd76263cbd0,species,yunnanensis,Eulophia,,Rolfe,,1903,,"J. Linn. Soc., Bot. 36: 29 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,635015-1,wfo-0000960376,5305652,,
 88120246-8fcd-11eb-924d-9cd76263cbd0,species,yushuiana,Eulophia,,S.Y.Hu,,1972,,"Chung Chi J. 11: 19 1972",,,,,,635016-1,wfo-0000960377,5311695,,
 88121e5c-8fcd-11eb-924d-9cd76263cbd0,species,zeyheri,Eulophia,,Hook.f.,,,,"Bot. Mag. 119: t. 7330 1893",,,,,,635018-1,wfo-0000960378,5311921,,
 88123810-8fcd-11eb-924d-9cd76263cbd0,species,zeyheriana,Eulophia,,Sond.,,1846,,"Linnaea 19: 73 1846",,,,,,635019-1,wfo-0000960379,5311748,,

--- a/data/names/E/Eulophia.csv
+++ b/data/names/E/Eulophia.csv
@@ -6,48 +6,87 @@ e38d6490-8fd1-11eb-924d-9cd76263cbd0,genus,Eulophia,,,R.Br.,,1821,,"Bot. Reg. 7:
 87bc54fe-8fcd-11eb-924d-9cd76263cbd0,species,aculeata,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634393-1,wfo-0000959630,5311564,,
 87bc8b0e-8fcd-11eb-924d-9cd76263cbd0,subspecies,huttonii,Eulophia,aculeata,"(Rolfe) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 183 1965",,,,87e1699c-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959632,5311566,,
 87bca648-8fcd-11eb-924d-9cd76263cbd0,species,acuminata,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 39 1912",,,,,,634394-1,wfo-0000959633,5312014,,
-87bcc646-8fcd-11eb-924d-9cd76263cbd0,species,acutilabra,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927",,Q55778720,,,,634395-1,wfo-0000959634,5311420,,
+87bcc646-8fcd-11eb-924d-9cd76263cbd0,species,acutilabra,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
+
+
+",Q55778720,DOI:10.2307/4107556,,,634395-1,wfo-0000959634,5311420,,
 87bce3ec-8fcd-11eb-924d-9cd76263cbd0,species,adenoglossa,Eulophia,,"(Lindl.) Rchb.f.",,1878,,"Otia Bot. Hamburg. 66 1878",,,,,,634396-1,wfo-0000959635,5311293,,
 87bcfed6-8fcd-11eb-924d-9cd76263cbd0,species,aemula,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 26 1895",,,,,,634397-1,wfo-0000959636,5311394,,
-87bd1b3c-8fcd-11eb-924d-9cd76263cbd0,species,aequalis,Eulophia,,"(Lindl.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 182 1889",,Q55760323,,db44b5f0-8fcb-11eb-924d-9cd76263cbd0,,634398-1,wfo-0000959637,5312168,,
+87bd1b3c-8fcd-11eb-924d-9cd76263cbd0,species,aequalis,Eulophia,,"(Lindl.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 182 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db44b5f0-8fcb-11eb-924d-9cd76263cbd0,,634398-1,wfo-0000959637,5312168,,
 87bd5af2-8fcd-11eb-924d-9cd76263cbd0,species,agrostophylla,Eulophia,,F.M.Bailey,,1895,,"Proc. Roy. Soc. Queensland 11(1): 16 1895",,,,,,634399-1,wfo-0000959639,5312087,,
 87bd773a-8fcd-11eb-924d-9cd76263cbd0,species,albiflora,Eulophia,,"Edgew. ex Lindl.",,1858,,"J. Proc. Linn. Soc., Bot. 3: 24 1858",,,,,,634400-1,wfo-0000959640,5311470,,
 af203598-8fd1-11eb-924d-9cd76263cbd0,species,albo-brunnea,Eulophia,,"Kraenzl. ex Engl.",,1906,,"Sitz. Preuss. Akad. Wiss. 739 1906",,,,,,634401-1,wfo-0001222933,8080320,,
 87bd9166-8fcd-11eb-924d-9cd76263cbd0,species,albobrunnea,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 69 1902",,,,,,634402-1,wfo-0000959641,5311991,,
-87bdadcc-8fcd-11eb-924d-9cd76263cbd0,species,alexandri,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 587 1975",,Q105743545,,db44f240-8fcb-11eb-924d-9cd76263cbd0,,634403-1,wfo-0000959642,5311658,,
+87bdadcc-8fcd-11eb-924d-9cd76263cbd0,species,alexandri,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db44f240-8fcb-11eb-924d-9cd76263cbd0,,634403-1,wfo-0000959642,5311658,,
 87bdca82-8fcd-11eb-924d-9cd76263cbd0,species,alismatophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 543 1885",,,,,,634404-1,wfo-0000959643,5323761,,
-87bde4d6-8fcd-11eb-924d-9cd76263cbd0,species,aliwalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910",,Q55782215,,,,634405-1,wfo-0000959644,5311414,,
+87bde4d6-8fcd-11eb-924d-9cd76263cbd0,species,aliwalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248
+
+
+",Q55782215,DOI:10.2307/4113248,,,634405-1,wfo-0000959644,5311414,,
 87bdff20-8fcd-11eb-924d-9cd76263cbd0,species,allisonii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 39 1912",,,,,,634406-1,wfo-0000959645,5312013,,
 87be1a78-8fcd-11eb-924d-9cd76263cbd0,species,aloifolia,Eulophia,,"Welw. ex Rchb.f.",,1867,,"Flora 50: 104 1867",,,,,,634407-1,wfo-0000959646,5311831,,
 87be3792-8fcd-11eb-924d-9cd76263cbd0,species,alta,Eulophia,,"(L.) Fawc. & Rendle",,1910,,"Fl. Jamaica 1: 112 1910",,,,,,99292-2,wfo-0000959647,5311790,,
 87be53a8-8fcd-11eb-924d-9cd76263cbd0,variety,alba,Eulophia,alta,L.C.Menezes,,1998,,"Bol. CAOB 33: 70 1998",,,,,,320902-2,wfo-0000959648,5311802,,
-54574ea8-8fcc-11eb-924d-9cd76263cbd0,form,flavescens,Eulophia,alta,"(Schltr.) F.Barros",,2004,,"Orchid Memories 20 2004",,Q16613943,,,,77062297-1,wfo-0000416183,5311808,,
+54574ea8-8fcc-11eb-924d-9cd76263cbd0,form,flavescens,Eulophia,alta,"(Schltr.) F.Barros",,2004,,"Orchid Memories 20 2004","Seidenfaden, G., Manilal, K. S., Kumar, C. S., & Taxonomy, I. A. for A. (2004). Orchid memories (p. 265).
+
+
+",Q16613943,,,,77062297-1,wfo-0000416183,5311808,,
 35a71604-8fcd-11eb-924d-9cd76263cbd0,variety,pachystelidia,Eulophia,alta,"(Rchb.f.) G.A.Romero",,2005,,"Vanishing Beauty, Native Costa Rican Orchids 1: 318 2005",,,,,,77069774-1,wfo-0000805776,,,
 87be8c42-8fcd-11eb-924d-9cd76263cbd0,form,pallida,Eulophia,alta,P.M.Br.,,1995,,"N. Amer. Native Orchid J. 1: 132 1995",,,,,,985132-1,wfo-0000959650,5311793,,
 87bea682-8fcd-11eb-924d-9cd76263cbd0,form,pelchatii,Eulophia,alta,P.M.Br.,,1998,,"N. Amer. Native Orchid J. 4: 46 1998",,,,,,315481-2,wfo-0000959651,5311811,,
-87bec00e-8fcd-11eb-924d-9cd76263cbd0,species,amajubae,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924",,Q100705852,,,,634409-1,wfo-0000959652,5311396,,
+87bec00e-8fcd-11eb-924d-9cd76263cbd0,species,amajubae,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634409-1,wfo-0000959652,5311396,,
 87bedc4c-8fcd-11eb-924d-9cd76263cbd0,species,ambaxiana,Eulophia,,J.J.Sm.,,1909,,"Nova Guinea 8: 26 1909",,,,,,634410-1,wfo-0000959653,5311757,,
-87bef786-8fcd-11eb-924d-9cd76263cbd0,species,amblyosepala,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 587 1975",,Q105743545,,c4494e18-8fcd-11eb-924d-9cd76263cbd0,,634411-1,wfo-0000959654,5311590,,
+87bef786-8fcd-11eb-924d-9cd76263cbd0,species,amblyosepala,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,c4494e18-8fcd-11eb-924d-9cd76263cbd0,,634411-1,wfo-0000959654,5311590,,
 87bf303e-8fcd-11eb-924d-9cd76263cbd0,species,amblypetala,Eulophia,,Kraenzl.,,1923,,"Vierteljahrsschr. Naturf. Ges. Zürich 68: 420 1923",,,,,,634412-1,wfo-0000959655,5311911,,
 87bfb590-8fcd-11eb-924d-9cd76263cbd0,species,ambongensis,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 169 1913",,,,,,634413-1,wfo-0000959656,5323745,,
 87c00040-8fcd-11eb-924d-9cd76263cbd0,species,ambositrana,Eulophia,,Schltr.,,1916,,"Beih. Bot. Centralbl. 34(2): 331 1916",,,,,,634414-1,wfo-0000959657,5311875,,
-87c01c60-8fcd-11eb-924d-9cd76263cbd0,species,ambrensis,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 587 1975",,Q105743545,,,,634415-1,wfo-0000959658,5323763,,
-87c039b6-8fcd-11eb-924d-9cd76263cbd0,species,amplipetala,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924",,Q100705852,,,,634416-1,wfo-0000959659,5312111,,
+87c01c60-8fcd-11eb-924d-9cd76263cbd0,species,ambrensis,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634415-1,wfo-0000959658,5323763,,
+87c039b6-8fcd-11eb-924d-9cd76263cbd0,species,amplipetala,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634416-1,wfo-0000959659,5312111,,
 87c07520-8fcd-11eb-924d-9cd76263cbd0,species,andamanensis,Eulophia,,Rchb.f.,,1872,,"Flora 55: 276 1872",,,,,,634417-1,wfo-0000959661,5311302,,
 87c08f2e-8fcd-11eb-924d-9cd76263cbd0,species,andersonii,Eulophia,,"(Rolfe) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,,,634418-1,wfo-0000959662,5311348,,
-87c0aaf4-8fcd-11eb-924d-9cd76263cbd0,species,angolensis,Eulophia,,"(Rchb.f.) Summerh.",,1958,,"Kew Bull. 13: 76 1958",,Q55785005,,,,634419-1,wfo-0000959663,5312088,,
+87c0aaf4-8fcd-11eb-924d-9cd76263cbd0,species,angolensis,Eulophia,,"(Rchb.f.) Summerh.",,1958,,"Kew Bull. 13: 76 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634419-1,wfo-0000959663,5312088,,
 87c0cab6-8fcd-11eb-924d-9cd76263cbd0,variety,mweruensis,Eulophia,angolensis,"(P.J.Cribb) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 645 1992",,,,87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,,967481-1,wfo-0000959664,5311532,,
 d239eef2-8fd1-11eb-924d-9cd76263cbd0,species,angornensis,Eulophia,,"(Rchb.f.) Hermans",,2007,,"Orchids Madagasc. (ed. 2) 178 2007",,,,8b87a16a-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0001282934,7511634,,
 87c160ca-8fcd-11eb-924d-9cd76263cbd0,species,angornensis,Eulophia,,"(Rchb.f.) P.J.Cribb",,1998,,"Lindleyana 13: 174 1998",,,,8b87a16a-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959669,5311896,,
 87c0e80c-8fcd-11eb-924d-9cd76263cbd0,species,angustiflora,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 396 1909",,,,,,634420-1,wfo-0000959665,5311430,,
 87c10468-8fcd-11eb-924d-9cd76263cbd0,species,angustilabellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 109 1919",,,,,,634421-1,wfo-0000959666,5311900,,
-87c121b4-8fcd-11eb-924d-9cd76263cbd0,species,angustilabris,Eulophia,,Seidenf.,,1985,,"Nordic J. Bot. 5: 166 1985",,Q55761278,,,,906057-1,wfo-0000959667,5311981,,
-87c1443c-8fcd-11eb-924d-9cd76263cbd0,species,anisotepala,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927",,Q55778719,,,,634422-1,wfo-0000959668,5312037,,
+87c121b4-8fcd-11eb-924d-9cd76263cbd0,species,angustilabris,Eulophia,,Seidenf.,,1985,,"Nordic J. Bot. 5: 166 1985","Seidenfaden, G. (2008). Contributions to the orchid flora of Thailand XI. Nordic Journal of Botany, 5(2), 157–167. https://doi.org/10.1111/j.1756-1051.1985.tb02085.x
+
+
+",Q55761278,DOI:10.1111/j.1756-1051.1985.tb02085.x,,,906057-1,wfo-0000959667,5311981,,
+87c1443c-8fcd-11eb-924d-9cd76263cbd0,species,anisotepala,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555
+
+
+",Q55778719,DOI:10.2307/4107555,,,634422-1,wfo-0000959668,5312037,,
 bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.J.Cribb",,1999,,"Orchids Madagasc. 4 1999",,,,af3ae618-8fd1-11eb-924d-9cd76263cbd0,,,wfo-0001249600,7705343,,
 87c17d4e-8fcd-11eb-924d-9cd76263cbd0,species,antennata,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 334 1899",,,,,,634423-1,wfo-0000959670,5311544,,
 87c1cb0a-8fcd-11eb-924d-9cd76263cbd0,species,antennisepala,Eulophia,,"(Rchb.f.) Schltr.",,1900,,"Westafr. Kautschuk-Exped. 279 1900",,,,,,634424-1,wfo-0000959673,5311531,,
 87c1e4d2-8fcd-11eb-924d-9cd76263cbd0,species,antunesii,Eulophia,,Rolfe,,1889,,"Bol. Soc. Brot. 7: 236 1889",,,,,,634425-1,wfo-0000959674,5311776,,
-87c201b0-8fcd-11eb-924d-9cd76263cbd0,species,arenaria,Eulophia,,"(Lindl.) Bolus",,1898,,"J. Linn. Soc., Bot. 25: 185 1898",,Q55760323,,,,634426-1,wfo-0000959675,5311626,,
+87c201b0-8fcd-11eb-924d-9cd76263cbd0,species,arenaria,Eulophia,,"(Lindl.) Bolus",,1898,,"J. Linn. Soc., Bot. 25: 185 1898","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634426-1,wfo-0000959675,5311626,,
 87c21eac-8fcd-11eb-924d-9cd76263cbd0,species,arenicola,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634427-1,wfo-0000959676,5311745,,
 87c23af4-8fcd-11eb-924d-9cd76263cbd0,species,argentina,Eulophia,,"(Rolfe) Schltr.",,1915,,"Bot. Jahrb. Syst. 53: 574 1915",,,,ff32ccfe-8fcb-11eb-924d-9cd76263cbd0,,634428-1,wfo-0000959677,5312019,,
 87c2561a-8fcd-11eb-924d-9cd76263cbd0,species,aristata,Eulophia,,Rendle,,1895,,"J. Bot. 33: 169 1895",,,,,,634429-1,wfo-0000959678,5311297,,
@@ -57,7 +96,10 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c2ca1e-8fcd-11eb-924d-9cd76263cbd0,species,aurantiaca,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634433-1,wfo-0000959682,5311465,,
 87c2fe94-8fcd-11eb-924d-9cd76263cbd0,species,aurea,Eulophia,,Kraenzl.,,1897,,"Bull. Herb. Boissier 5: 635 1897",,,,,,634434-1,wfo-0000959684,5311357,,
 87c3192e-8fcd-11eb-924d-9cd76263cbd0,species,austrooccidentalis,Eulophia,,Sölch,,1956,,"Mitt. Bot. Staatssamml. München 2: 177 1956",,,,,,,wfo-0000959685,5311523,,
-87c33648-8fcd-11eb-924d-9cd76263cbd0,species,badinii,Eulophia,,R.J.V.Alves,,1991,,"Folia Geobot. Phytotax. 26: 102 1991",,Q55755442,,,,959817-1,wfo-0000959686,5543354,,
+87c33648-8fcd-11eb-924d-9cd76263cbd0,species,badinii,Eulophia,,R.J.V.Alves,,1991,,"Folia Geobot. Phytotax. 26: 102 1991","Alves, R. J. V. (1991). A new species of the genus Eulophia R. Br. (Orchidaceae) from Minas Gerais, Brazil. Folia Geobotanica Et Phytotaxonomica, 26(1), 101–106. https://doi.org/10.1007/bf02912945
+
+
+",Q55755442,DOI:10.1007/bf02912945,,,959817-1,wfo-0000959686,5543354,,
 87c353f8-8fcd-11eb-924d-9cd76263cbd0,species,baginsensis,Eulophia,,Rchb.f.,,1878,,"Otia Bot. Hamburg. 66 1878",,,,,,634436-1,wfo-0000959687,5311787,,
 87c370d6-8fcd-11eb-924d-9cd76263cbd0,species,bainesii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 65 1897",,,,,,634437-1,wfo-0000959688,5312005,,
 87c38a94-8fcd-11eb-924d-9cd76263cbd0,species,bakeri,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 40 1912",,,,,,634438-1,wfo-0000959689,5311998,,
@@ -69,7 +111,10 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c443a8-8fcd-11eb-924d-9cd76263cbd0,species,baumiana,Eulophia,,Kraenzl.,,1903,,"Kunene-Sambesi Exped. 213 1903",,,,,,634445-1,wfo-0000959696,5311299,,
 87c45d20-8fcd-11eb-924d-9cd76263cbd0,species,bella,Eulophia,,N.E.Br.,,1889,,"Gard. Chron. III, 6: 210 1889",,,,,,,wfo-0000959697,5312122,,
 87c47936-8fcd-11eb-924d-9cd76263cbd0,species,beravensis,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 74 1881",,,,,,634448-1,wfo-0000959698,5311876,,
-87c49344-8fcd-11eb-924d-9cd76263cbd0,species,bicallosa,Eulophia,,"(D.Don) P.F.Hunt & Summerh.",,1966,,"Kew Bull. 20: 60 1966",,Q43250382,,2179caa6-8fcc-11eb-924d-9cd76263cbd0,,634449-1,wfo-0000959699,5311839,,
+87c49344-8fcd-11eb-924d-9cd76263cbd0,species,bicallosa,Eulophia,,"(D.Don) P.F.Hunt & Summerh.",,1966,,"Kew Bull. 20: 60 1966","Hunt, P. F., & Summerhayes, V. S. (1966). Notes on Asiatic Orchids: IV. Kew Bulletin, 20(1), 51–61. https://doi.org/10.2307/4107882
+
+
+",Q43250382,DOI:10.2307/4107882,2179caa6-8fcc-11eb-924d-9cd76263cbd0,,634449-1,wfo-0000959699,5311839,,
 87c4b0f4-8fcd-11eb-924d-9cd76263cbd0,variety,major,Eulophia,bicallosa,"(King & Pantl.) Pradhan",,1979,,"Indian Orchids: Guide Identif. & Cult. 2: 461 1979",,,,87c4e9ca-8fcd-11eb-924d-9cd76263cbd0,,887509-1,wfo-0000959700,5311846,,
 87c4cd28-8fcd-11eb-924d-9cd76263cbd0,species,bicarinata,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 6 1890",,,,,,634450-1,wfo-0000959701,5311842,,
 87c4e9ca-8fcd-11eb-924d-9cd76263cbd0,variety,major,Eulophia,bicarinata,"King & Pantl.",,1898,,"Ann. Roy. Bot. Gard. (Calcutta) 8: 181 1898",,,,,,,wfo-0000959702,5311848,,
@@ -85,8 +130,14 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c62204-8fcd-11eb-924d-9cd76263cbd0,species,bletilloides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 576 1915",,,,,,634459-1,wfo-0000959713,5311821,,
 87c63dd4-8fcd-11eb-924d-9cd76263cbd0,species,boltonii,Eulophia,,"Harv. ex Rolfe",,1912,,"Fl. Cap. 5(3): 53 1912",,,,,,634460-1,wfo-0000959714,5312074,,
 545a1e62-8fcc-11eb-924d-9cd76263cbd0,species,borbonica,Eulophia,,Bosser,,2002,,"Adansonia III, 24: 22 2002",,,,,,20006676-1,wfo-0000416190,5311891,,
-87c657a6-8fcd-11eb-924d-9cd76263cbd0,species,borneensis,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 31: 289 1896",,Q55760384,,,,634462-1,wfo-0000959715,5312077,,
-87c670a6-8fcd-11eb-924d-9cd76263cbd0,species,bouharmontii,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990",,Q55776633,,,,940391-1,wfo-0000959716,5311744,,
+87c657a6-8fcd-11eb-924d-9cd76263cbd0,species,borneensis,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 31: 289 1896","Ridley, H. N. (1896). An Enumeration of all Orchideae hitherto recorded from Borneo. Transactions of the Linnean Society of London: Botany, 31(215), 261–306. https://doi.org/10.1111/j.1095-8339.1896.tb00808.x
+
+
+",Q55760384,DOI:10.1111/j.1095-8339.1896.tb00808.x,,,634462-1,wfo-0000959715,5312077,,
+87c670a6-8fcd-11eb-924d-9cd76263cbd0,species,bouharmontii,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940391-1,wfo-0000959716,5311744,,
 87c68e06-8fcd-11eb-924d-9cd76263cbd0,species,bouliawongo,Eulophia,,"(Rchb.f.) J.Raynal",,1965,,"Rev. Soc. Savantes Haute Normandie 1965: 47 1966",,,,8b88ffce-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959717,5312022,,
 87c6a774-8fcd-11eb-924d-9cd76263cbd0,species,brachycentra,Eulophia,,Hayata,,1914,,"Icon. Pl. Formosan. 4: 72 1914",,,,,,634463-1,wfo-0000959718,5311841,,
 87c6c416-8fcd-11eb-924d-9cd76263cbd0,species,brachypetala,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 24 1858",,,,,,634464-1,wfo-0000959719,5311473,,
@@ -94,34 +145,64 @@ bd9dc950-8fd1-11eb-924d-9cd76263cbd0,species,anjoanensis,Eulophia,,"(Rchb.f.) P.
 87c6f972-8fcd-11eb-924d-9cd76263cbd0,species,bracteosa,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,,wfo-0000959721,5311923,,
 87c715b0-8fcd-11eb-924d-9cd76263cbd0,species,brenanii,Eulophia,,"P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 536 1998",,,,,,1005718-1,wfo-0000959722,5311881,,
 87c73068-8fcd-11eb-924d-9cd76263cbd0,species,brevipetala,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 53 1897",,,,,,634467-1,wfo-0000959723,5311835,,
-87c74cf6-8fcd-11eb-924d-9cd76263cbd0,species,brevisepala,Eulophia,,"(Rendle) Summerh.",,1953,,"Kew Bull. 8: 147 1953",,Q55784833,,,,634468-1,wfo-0000959724,5311501,,
-87c769ac-8fcd-11eb-924d-9cd76263cbd0,species,brunnea,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975",,Q105743545,,,,634469-1,wfo-0000959725,5311538,,
+87c74cf6-8fcd-11eb-924d-9cd76263cbd0,species,brevisepala,Eulophia,,"(Rendle) Summerh.",,1953,,"Kew Bull. 8: 147 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
+
+
+",Q55784833,DOI:10.2307/4117167,,,634468-1,wfo-0000959724,5311501,,
+87c769ac-8fcd-11eb-924d-9cd76263cbd0,species,brunnea,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634469-1,wfo-0000959725,5311538,,
 87c7a476-8fcd-11eb-924d-9cd76263cbd0,species,brunneorubra,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 583 1915",,,,,,634470-1,wfo-0000959727,5311364,,
 87c7f7aa-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 19 1894",,,,,,634472-1,wfo-0000959730,7367438,,
-87c7bfc4-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889",,Q55760323,,,,634471-1,wfo-0000959728,5311397,,
+87c7bfc4-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634471-1,wfo-0000959728,5311397,,
 87c7db44-8fcd-11eb-924d-9cd76263cbd0,species,buchananii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 64 1897",,,,,,634473-1,wfo-0000959729,7481908,,
 87c8129e-8fcd-11eb-924d-9cd76263cbd0,species,buettneri,Eulophia,,"(Kraenzl.) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 446 1936",,,,db490fc4-8fcb-11eb-924d-9cd76263cbd0,,634474-1,wfo-0000959731,5311560,,
-87c82fae-8fcd-11eb-924d-9cd76263cbd0,species,bulbinoides,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 234 1924",,Q100705852,,,,634475-1,wfo-0000959732,5311448,,
-87c84c00-8fcd-11eb-924d-9cd76263cbd0,species,burkei,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925",,Q55778673,,,,634476-1,wfo-0000959733,5312150,,
+87c82fae-8fcd-11eb-924d-9cd76263cbd0,species,bulbinoides,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 234 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634475-1,wfo-0000959732,5311448,,
+87c84c00-8fcd-11eb-924d-9cd76263cbd0,species,burkei,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477
+
+
+",Q55778673,DOI:10.2307/4107477,,,634476-1,wfo-0000959733,5312150,,
 87c8685c-8fcd-11eb-924d-9cd76263cbd0,species,burmanica,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 5 1890",,,,,,634477-1,wfo-0000959734,5311417,,
 87c8829c-8fcd-11eb-924d-9cd76263cbd0,species,burundiensis,Eulophia,,"Arbonn. & Geerinck",,1993,,"Belgian J. Bot. 126: 257 1993 publ. 1994",,,,,,976618-1,wfo-0000959735,5311333,,
-87c89f5c-8fcd-11eb-924d-9cd76263cbd0,species,busseana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975",,Q105743545,,,,634478-1,wfo-0000959736,5311961,,
+87c89f5c-8fcd-11eb-924d-9cd76263cbd0,species,busseana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634478-1,wfo-0000959736,5311961,,
 87c8d724-8fcd-11eb-924d-9cd76263cbd0,species,caffra,Eulophia,,Rchb.f.,,1865,,"Flora 48: 186 1865",,,,,,634479-1,wfo-0000959738,5311783,,
 87c8f380-8fcd-11eb-924d-9cd76263cbd0,species,calantha,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 215 1903",,,,,,634480-1,wfo-0000959739,5312062,,
 87c9116c-8fcd-11eb-924d-9cd76263cbd0,variety,kubangensis,Eulophia,calantha,Schltr.,,1903,,"Kunene-Sambesi Exped. 216 1903",,,,,,,wfo-0000959740,5312065,,
 87c92d5a-8fcd-11eb-924d-9cd76263cbd0,species,calanthoides,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 1 1895",,,,,,634481-1,wfo-0000959741,5312011,,
 87c9493e-8fcd-11eb-924d-9cd76263cbd0,species,calcarata,Eulophia,,"(Schltr.) Schltr.",,1925,,"Repert. Spec. Nov. Regni Veg. Beih. 33: 262 1925",,,,,,634482-1,wfo-0000959742,5323757,,
 87c96586-8fcd-11eb-924d-9cd76263cbd0,species,callichroma,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 116 1881",,,,,,634483-1,wfo-0000959743,5311898,,
-87c9819c-8fcd-11eb-924d-9cd76263cbd0,species,caloptera,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 133 1947 publ. 1948",,Q43263417,,,,634484-1,wfo-0000959744,5311521,,
-87c99f74-8fcd-11eb-924d-9cd76263cbd0,species,cambodiensis,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930",,Q55757232,,,,634485-1,wfo-0000959745,5311772,,
+87c9819c-8fcd-11eb-924d-9cd76263cbd0,species,caloptera,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 133 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211
+
+
+",Q43263417,DOI:10.2307/4109211,,,634484-1,wfo-0000959744,5311521,,
+87c99f74-8fcd-11eb-924d-9cd76263cbd0,species,cambodiensis,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
+
+
+",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634485-1,wfo-0000959745,5311772,,
 87c9bcb6-8fcd-11eb-924d-9cd76263cbd0,species,campanulata,Eulophia,,Duthie,,1902,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 71: 39 1902",,,,,,634486-1,wfo-0000959746,5311826,,
 87c9da20-8fcd-11eb-924d-9cd76263cbd0,species,campbellii,Eulophia,,Prain,,1904,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 73: 190 1904",,,,,,634487-1,wfo-0000959747,5311778,,
 c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Numer. List n. 7367 1828",,,,,,634488-1,wfo-0001088105,8085160,,
 87ca1044-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,"Wall. ex Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,,wfo-0000959749,5311488,,
 87ca2a66-8fcd-11eb-924d-9cd76263cbd0,species,camporum,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 170 1913",,,,,,634489-1,wfo-0000959750,5311889,,
 87ca4532-8fcd-11eb-924d-9cd76263cbd0,species,candida,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 6 1890",,,,,,634490-1,wfo-0000959751,5311849,,
-87ca5eaa-8fcd-11eb-924d-9cd76263cbd0,species,candidiflora,Eulophia,,Butzin,,1975,,"Willdenowia 7: 587 1975",,Q105743545,,,,634491-1,wfo-0000959752,5311677,,
-87ca7b06-8fcd-11eb-924d-9cd76263cbd0,species,capensis,Eulophia,,"(L.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882",,Q55760231,,,,634492-1,wfo-0000959753,5311571,,
+87ca5eaa-8fcd-11eb-924d-9cd76263cbd0,species,candidiflora,Eulophia,,Butzin,,1975,,"Willdenowia 7: 587 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634491-1,wfo-0000959752,5311677,,
+87ca7b06-8fcd-11eb-924d-9cd76263cbd0,species,capensis,Eulophia,,"(L.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
+
+
+",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634492-1,wfo-0000959753,5311571,,
 87ca9726-8fcd-11eb-924d-9cd76263cbd0,species,caricifolia,Eulophia,,"(Rchb.f.) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634493-1,wfo-0000959754,5311525,,
 87cab2e2-8fcd-11eb-924d-9cd76263cbd0,variety,antennisepala,Eulophia,caricifolia,"(Rchb.f.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 647 1992",,,,,,967482-1,wfo-0000959755,,,
 87cad01a-8fcd-11eb-924d-9cd76263cbd0,species,carinata,Eulophia,,"(Willd.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 183 1833",,,,,,634494-1,wfo-0000959756,5311550,,
@@ -130,19 +211,31 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cb21aa-8fcd-11eb-924d-9cd76263cbd0,species,carunculifera,Eulophia,,Rchb.f.,,1881,,"Flora 64: 329 1881",,,,,,634497-1,wfo-0000959759,5311400,,
 87cb3bd6-8fcd-11eb-924d-9cd76263cbd0,species,celebica,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634498-1,wfo-0000959760,5312134,,
 87cb55d0-8fcd-11eb-924d-9cd76263cbd0,species,chaunanthe,Eulophia,,Seidenf.,,1983,,"Opera Bot. 72: 34 1983 publ. 1984",,,,,,904162-1,wfo-0000959761,5312084,,
-87cb6fc0-8fcd-11eb-924d-9cd76263cbd0,species,chilangensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927",,Q55778719,,,,634499-1,wfo-0000959762,5312057,,
+87cb6fc0-8fcd-11eb-924d-9cd76263cbd0,species,chilangensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 415 1927","Green, M. L. (1927). History of Plant Nomenclature. Bulletin of Miscellaneous Information, 1927(10), 403. https://doi.org/10.2307/4107555
+
+
+",Q55778719,DOI:10.2307/4107555,,,634499-1,wfo-0000959762,5312057,,
 87cb8bfe-8fcd-11eb-924d-9cd76263cbd0,species,chlorantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 9 1895",,,,,,634500-1,wfo-0000959763,5312008,,
 87cba864-8fcd-11eb-924d-9cd76263cbd0,species,chlorotica,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 389 1914",,,,,,634501-1,wfo-0000959764,5311747,,
 87cbc2d6-8fcd-11eb-924d-9cd76263cbd0,species,chrysantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 2 1895",,,,,,634502-1,wfo-0000959765,5311371,,
 87cbdece-8fcd-11eb-924d-9cd76263cbd0,species,chrysoglossoides,Eulophia,,Schltr.,,1906,,"Bull. Herb. Boissier II, 6: 453 1906",,,,,,634503-1,wfo-0000959766,5311932,,
-87cbf850-8fcd-11eb-924d-9cd76263cbd0,species,chrysops,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958",,Q55785005,,,,634504-1,wfo-0000959767,5311324,,
+87cbf850-8fcd-11eb-924d-9cd76263cbd0,species,chrysops,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634504-1,wfo-0000959767,5311324,,
 87cc14e8-8fcd-11eb-924d-9cd76263cbd0,species,ciliata,Eulophia,,"(Schumach.) Rchb.f.",,1863,,"Ann. Bot. Syst. 6: 647 1863",,,,fef87f1e-8fb1-11eb-924d-9cd76263cbd0,,634505-1,wfo-0000959768,5311454,,
-87cc4b16-8fcd-11eb-924d-9cd76263cbd0,species,circinnata,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910",,Q55781794,,,,634506-1,wfo-0000959770,5311781,,
+87cc4b16-8fcd-11eb-924d-9cd76263cbd0,species,circinnata,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719
+
+
+",Q55781794,DOI:10.2307/4111719,,,634506-1,wfo-0000959770,5311781,,
 87cc66d2-8fcd-11eb-924d-9cd76263cbd0,species,clandestina,Eulophia,,"(Börge Pett.) Bytebier",,2008,,"Strelitzia 22: 190 2008",,,,ff332316-8fcb-11eb-924d-9cd76263cbd0,,77095523-1,wfo-0000959771,5311823,,
 87cc82d4-8fcd-11eb-924d-9cd76263cbd0,species,clavicornis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634507-1,wfo-0000959772,5311386,,
 87ccc014-8fcd-11eb-924d-9cd76263cbd0,variety,inaequalis,Eulophia,clavicornis,"(Schltr.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 82 1965",,,,,,,wfo-0000959774,5311412,,
 87ccdcde-8fcd-11eb-924d-9cd76263cbd0,variety,nutans,Eulophia,clavicornis,"(Sond.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 82 1965",,,,87f32420-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000959775,5311393,,
-87ccf8b8-8fcd-11eb-924d-9cd76263cbd0,species,clitellifera,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889",,Q55760323,,,,634508-1,wfo-0000959776,5311598,,
+87ccf8b8-8fcd-11eb-924d-9cd76263cbd0,species,clitellifera,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634508-1,wfo-0000959776,5311598,,
 87cd1578-8fcd-11eb-924d-9cd76263cbd0,species,coccifera,Eulophia,,"Frapp. ex Cordem.",,1895,,"Fl. Réunion 222 1895",,,,,,634509-1,wfo-0000959777,5311582,,
 87cd3148-8fcd-11eb-924d-9cd76263cbd0,species,cochlearis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634511-1,wfo-0000959778,5312506,,
 87cd4ad4-8fcd-11eb-924d-9cd76263cbd0,species,coddii,Eulophia,,A.V.Hall,,1965,,"J. S. African Bot. Suppl. 5: 134 1965",,,,,,634512-1,wfo-0000959779,5311495,,
@@ -151,7 +244,10 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cdd40e-8fcd-11eb-924d-9cd76263cbd0,species,collina,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 336 1899",,,,,,634515-1,wfo-0000959784,5311594,,
 87cdedcc-8fcd-11eb-924d-9cd76263cbd0,species,comosa,Eulophia,,Sond.,,1846,,"Linnaea 19: 72 1846",,,,,,634516-1,wfo-0000959785,5312510,,
 87ce09f6-8fcd-11eb-924d-9cd76263cbd0,species,complanata,Eulophia,,Verd.,,,,"Fl. Pl. Africa 27: t. 1056 1949",,,,,,634517-1,wfo-0000959786,5312003,,
-87ce23c8-8fcd-11eb-924d-9cd76263cbd0,species,compta,Eulophia,,Summerh.,,1951,,"Kew Bull. 6: 472 1951 publ. 1952",,Q43261270,,,,634518-1,wfo-0000959787,5311321,,
+87ce23c8-8fcd-11eb-924d-9cd76263cbd0,species,compta,Eulophia,,Summerh.,,1951,,"Kew Bull. 6: 472 1951 publ. 1952","Summerhayes, V. S. (1951). African Orchids: XX. Kew Bulletin, 6(3), 461–475. https://doi.org/10.2307/4118030
+
+
+",Q43261270,DOI:10.2307/4118030,,,634518-1,wfo-0000959787,5311321,,
 87ce40d8-8fcd-11eb-924d-9cd76263cbd0,species,concinna,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 581 1915",,,,,,634519-1,wfo-0000959788,5312038,,
 87ce5ae6-8fcd-11eb-924d-9cd76263cbd0,species,concolor,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,da681d20-8fcb-11eb-924d-9cd76263cbd0,,634520-1,wfo-0000959789,5308340,,
 87ce74f4-8fcd-11eb-924d-9cd76263cbd0,species,congoensis,Eulophia,,Cogn.,,1895,,"J. Orchidées 6: 155 1895",,,,,,,wfo-0000959790,5311865,,
@@ -159,8 +255,14 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 87cec8fa-8fcd-11eb-924d-9cd76263cbd0,species,corallorhiziformis,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 9 1895",,,,,,634524-1,wfo-0000959793,5311450,,
 87cee484-8fcd-11eb-924d-9cd76263cbd0,species,cordylinophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 541 1885",,,,,,634525-1,wfo-0000959794,5323774,,
 87cefdd4-8fcd-11eb-924d-9cd76263cbd0,species,corymbosa,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 216 1903",,,,,,634526-1,wfo-0000959795,5311870,,
-87cf199a-8fcd-11eb-924d-9cd76263cbd0,species,coutreziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990",,Q55776633,,,,940392-1,wfo-0000959796,5311512,,
-87cf3588-8fcd-11eb-924d-9cd76263cbd0,species,crepidata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634527-1,wfo-0000959797,5311721,,
+87cf199a-8fcd-11eb-924d-9cd76263cbd0,species,coutreziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 183 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940392-1,wfo-0000959796,5311512,,
+87cf3588-8fcd-11eb-924d-9cd76263cbd0,species,crepidata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634527-1,wfo-0000959797,5311721,,
 87cf6ef4-8fcd-11eb-924d-9cd76263cbd0,species,crinita,Eulophia,,"(P.N.Don) G.Don",,1850,,"Suppl. Hort. Brit. 588 1850",,,,,,,wfo-0000959799,7721138,,
 87cf5298-8fcd-11eb-924d-9cd76263cbd0,species,crinita,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 58 1897",,,,,,634529-1,wfo-0000959798,5310370,,
 87cf88da-8fcd-11eb-924d-9cd76263cbd0,species,cristata,Eulophia,,"(Afzel. ex Sw.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000959800,5311673,,
@@ -168,18 +270,33 @@ c3a18a70-8fcd-11eb-924d-9cd76263cbd0,species,campestris,Eulophia,,Wall.,,,,"Nume
 545c53b2-8fcc-11eb-924d-9cd76263cbd0,variety,dilecta,Eulophia,cucullata,"(Rchb.f.) Pérez-Vera",,2003,,"Orchidées Côte D'Ivoire 321 2003",,,,,,70027675-1,wfo-0000416197,,,
 af44d89e-8fd1-11eb-924d-9cd76263cbd0,species,cullenii,Eulophia,,"(Wight) C.E.C.Fisch.",,,,"Fl. Madras 1435 1928",,,,7d2c5f5c-8fcd-11eb-924d-9cd76263cbd0,,634534-1,wfo-0001223208,7942127,,
 87cfd984-8fcd-11eb-924d-9cd76263cbd0,species,cullenii,Eulophia,,"(Wight) Blume",,1859,,"Coll. Orchid. 182 1859",,,,7d2c5f5c-8fcd-11eb-924d-9cd76263cbd0,,634533-1,wfo-0000959803,5311462,,
-87cff32e-8fcd-11eb-924d-9cd76263cbd0,species,culveri,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924",,Q100705852,,,,634535-1,wfo-0000959804,5311573,,
+87cff32e-8fcd-11eb-924d-9cd76263cbd0,species,culveri,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 238 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634535-1,wfo-0000959804,5311573,,
 87d00f26-8fcd-11eb-924d-9cd76263cbd0,species,cyrtosioides,Eulophia,,Schltr.,,1900,,"Westafr. Kautschuk-Exped. 279 1900",,,,,,634536-1,wfo-0000959805,5311834,,
 af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr.",,1970,,"J. Bombay Nat. Hist. Soc. 67: 66 1970",,,,21ab52ec-8fcc-11eb-924d-9cd76263cbd0,,,wfo-0001223229,8263740,,
 87d02b32-8fcd-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) Hochr.",,1910,,"Bull. New York Bot. Gard. 6: 270 1910",,,,21ab52ec-8fcc-11eb-924d-9cd76263cbd0,,634538-1,wfo-0000959806,5311480,,
-87d044f0-8fcd-11eb-924d-9cd76263cbd0,species,dactylifera,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 163 1977",,Q43230546,,,,634540-1,wfo-0000959807,5311419,,
+87d044f0-8fcd-11eb-924d-9cd76263cbd0,species,dactylifera,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 163 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,634540-1,wfo-0000959807,5311419,,
 87d06318-8fcd-11eb-924d-9cd76263cbd0,species,dahliana,Eulophia,,Kraenzl.,,1896,,"Notizbl. Königl. Bot. Gart. Berlin 1: 243 1896",,,,,,634541-1,wfo-0000959808,5311335,,
 87d0800a-8fcd-11eb-924d-9cd76263cbd0,species,debeerstii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 111 1919",,,,,,634543-1,wfo-0000959809,5312079,,
 87d09c2a-8fcd-11eb-924d-9cd76263cbd0,species,decaryana,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935",,,,,,,wfo-0000959810,5323759,,
 87d0b836-8fcd-11eb-924d-9cd76263cbd0,species,decipiens,Eulophia,,Kurz,,1876,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 45(2): 155 1876",,,,,,634545-1,wfo-0000959811,5312158,,
-87d0f0bc-8fcd-11eb-924d-9cd76263cbd0,species,decurva,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 235 1924",,Q100705852,,,,634546-1,wfo-0000959813,5311404,,
-87d10caa-8fcd-11eb-924d-9cd76263cbd0,species,deflexa,Eulophia,,Rolfe,,1895,,"Bull. Misc. Inform. Kew 1895: 192 1895",,Q55783766,,,,634547-1,wfo-0000959814,5311999,,
-87d12622-8fcd-11eb-924d-9cd76263cbd0,species,delicata,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 169 1977",,Q43230546,,,,634548-1,wfo-0000959815,5311421,,
+87d0f0bc-8fcd-11eb-924d-9cd76263cbd0,species,decurva,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 235 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634546-1,wfo-0000959813,5311404,,
+87d10caa-8fcd-11eb-924d-9cd76263cbd0,species,deflexa,Eulophia,,Rolfe,,1895,,"Bull. Misc. Inform. Kew 1895: 192 1895","New Orchids.: Decade 14. (1895). Bulletin of Miscellaneous Information, 1895(104), 191. https://doi.org/10.2307/4114968
+
+
+",Q55783766,DOI:10.2307/4114968,,,634547-1,wfo-0000959814,5311999,,
+87d12622-8fcd-11eb-924d-9cd76263cbd0,species,delicata,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 169 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,634548-1,wfo-0000959815,5311421,,
 87d14210-8fcd-11eb-924d-9cd76263cbd0,species,densiflora,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634549-1,wfo-0000959816,5311972,,
 87d15b9c-8fcd-11eb-924d-9cd76263cbd0,species,dentata,Eulophia,,Ames,,1911,,"Philipp. J. Sci., C 6: 51 1911",,,,,,634550-1,wfo-0000959817,5311904,,
 87d17582-8fcd-11eb-924d-9cd76263cbd0,species,descampsii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 81 1919",,,,,,634551-1,wfo-0000959818,5311319,,
@@ -192,76 +309,139 @@ af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr
 87d24b56-8fcd-11eb-924d-9cd76263cbd0,species,dissimilis,Eulophia,,R.A.Dyer,,,,"Fl. Pl. Africa 27: t. 1066 1949",,,,,,634559-1,wfo-0000959826,5323731,,
 87d26802-8fcd-11eb-924d-9cd76263cbd0,species,divergens,Eulophia,,Fritsch,,,,"Bull. Herb. Boissier II, 1: 1118 1901",,,,,,,wfo-0000959827,5311622,,
 87d2842c-8fcd-11eb-924d-9cd76263cbd0,species,dregeana,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634561-1,wfo-0000959828,5311997,,
-87d29dcc-8fcd-11eb-924d-9cd76263cbd0,species,dufossei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930",,Q55757232,,,,634562-1,wfo-0000959829,5311535,,
-87d2b9d8-8fcd-11eb-924d-9cd76263cbd0,species,durbanensis,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 83 1917",,Q55782426,,,,634563-1,wfo-0000959830,5311369,,
+87d29dcc-8fcd-11eb-924d-9cd76263cbd0,species,dufossei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
+
+
+",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634562-1,wfo-0000959829,5311535,,
+87d2b9d8-8fcd-11eb-924d-9cd76263cbd0,species,durbanensis,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 83 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
+
+
+",Q55782426,DOI:10.2307/4113400,,,634563-1,wfo-0000959830,5311369,,
 87d2d35a-8fcd-11eb-924d-9cd76263cbd0,species,dusenii,Eulophia,,Kraenzl.,,1894,,"Bot. Jahrb. Syst. 19: 254 1894",,,,,,634564-1,wfo-0000959831,5311314,,
-87d2ef48-8fcd-11eb-924d-9cd76263cbd0,species,dybowskii,Eulophia,,"(God.-Leb.) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,db4f4c0e-8fcb-11eb-924d-9cd76263cbd0,,634565-1,wfo-0000959832,5311659,,
+87d2ef48-8fcd-11eb-924d-9cd76263cbd0,species,dybowskii,Eulophia,,"(God.-Leb.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db4f4c0e-8fcb-11eb-924d-9cd76263cbd0,,634565-1,wfo-0000959832,5311659,,
 87d32832-8fcd-11eb-924d-9cd76263cbd0,species,ecalcarata,Eulophia,,G.Will.,,1980,,"J. S. African Bot. 46: 336 1980",,,,,,634566-1,wfo-0000959834,5311820,,
-87d34434-8fcd-11eb-924d-9cd76263cbd0,species,ecarinata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634567-1,wfo-0000959835,5311561,,
+87d34434-8fcd-11eb-924d-9cd76263cbd0,species,ecarinata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634567-1,wfo-0000959835,5311561,,
 87d3605e-8fcd-11eb-924d-9cd76263cbd0,species,ecristata,Eulophia,,"(Fernald) Ames",,1904,,"Contr. Ames Bot. Lab. 1: 19 1904",,,,,,99294-2,wfo-0000959836,5312154,,
 87d37be8-8fcd-11eb-924d-9cd76263cbd0,species,elamellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 112 1919",,,,,,634569-1,wfo-0000959837,5311360,,
 87d3954c-8fcd-11eb-924d-9cd76263cbd0,species,elata,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 3 1890",,,,,,634570-1,wfo-0000959838,5312130,,
 87d3ae4c-8fcd-11eb-924d-9cd76263cbd0,species,elegans,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 585 1915",,,,,,634571-1,wfo-0000959839,5312010,,
-87d3c7e2-8fcd-11eb-924d-9cd76263cbd0,species,elegantula,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917",,Q55782426,,,,634572-1,wfo-0000959840,5312171,,
-87d3e59c-8fcd-11eb-924d-9cd76263cbd0,species,eleogena,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634573-1,wfo-0000959841,5311663,,
+87d3c7e2-8fcd-11eb-924d-9cd76263cbd0,species,elegantula,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
+
+
+",Q55782426,DOI:10.2307/4113400,,,634572-1,wfo-0000959840,5312171,,
+87d3e59c-8fcd-11eb-924d-9cd76263cbd0,species,eleogena,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634573-1,wfo-0000959841,5311663,,
 87d403ba-8fcd-11eb-924d-9cd76263cbd0,species,elliottii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 54 1897",,,,,,634575-1,wfo-0000959842,,,
 87d43c22-8fcd-11eb-924d-9cd76263cbd0,species,elongata,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634576-1,wfo-0000959844,5312148,,
 87d455f4-8fcd-11eb-924d-9cd76263cbd0,species,emarginata,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634577-1,wfo-0000959845,5311385,,
 87d4707a-8fcd-11eb-924d-9cd76263cbd0,species,emarginata,Eulophia,,Blume,,1859,,"Coll. Orchid. 180 1859",,,,,,634578-1,wfo-0000959846,7609323,,
 87d48ab0-8fcd-11eb-924d-9cd76263cbd0,species,emilianae,Eulophia,,C.J.Saldanha,,1974,,"Indian Forester 100: 566 1974",,,,,,,wfo-0000959847,5311775,,
 87d4a752-8fcd-11eb-924d-9cd76263cbd0,species,encyclioides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 577 1915",,,,,,634580-1,wfo-0000959848,5312059,,
-87d4c156-8fcd-11eb-924d-9cd76263cbd0,species,endlichiana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634581-1,wfo-0000959849,5543321,,
-87d4daa6-8fcd-11eb-924d-9cd76263cbd0,species,engleri,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910",,Q55781795,,,,634582-1,wfo-0000959850,5311409,,
+87d4c156-8fcd-11eb-924d-9cd76263cbd0,species,endlichiana,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634581-1,wfo-0000959849,5543321,,
+87d4daa6-8fcd-11eb-924d-9cd76263cbd0,species,engleri,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
+
+
+",Q55781795,DOI:10.2307/4111720,,,634582-1,wfo-0000959850,5311409,,
 87d4f7d4-8fcd-11eb-924d-9cd76263cbd0,species,ensata,Eulophia,,Lindl.,,,,"Bot. Reg. 14: t. 1147 1828",,,,,,634583-1,wfo-0000959851,5311616,,
-87d51458-8fcd-11eb-924d-9cd76263cbd0,species,ephippium,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634584-1,wfo-0000959852,5311583,,
+87d51458-8fcd-11eb-924d-9cd76263cbd0,species,ephippium,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634584-1,wfo-0000959852,5311583,,
 87d52e3e-8fcd-11eb-924d-9cd76263cbd0,species,epidendraea,Eulophia,,"(J.Koenig ex Retz.) C.E.C.Fisch.",,,,"Fl. Madras 1434 1928",,,,0c3943ce-8fcc-11eb-924d-9cd76263cbd0,,634585-1,wfo-0000959853,5311546,,
 87d56854-8fcd-11eb-924d-9cd76263cbd0,species,epidendroides,Eulophia,,"(Willd.) Schltr.",,1914,,"Orchideen 346 1914",,,,da69ee70-8fcb-11eb-924d-9cd76263cbd0,,634586-1,wfo-0000959855,5311553,,
 87d581ea-8fcd-11eb-924d-9cd76263cbd0,species,epiphanoides,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 575 1915",,,,,,634587-1,wfo-0000959856,5311464,,
 545df2bc-8fcc-11eb-924d-9cd76263cbd0,species,epiphytica,Eulophia,,"P.J.Cribb, Du Puy & Bosser",,2002,,"Adansonia III, 24: 170 2002",,,,,,20010520-1,wfo-0000416207,5313537,,
-87d59ba8-8fcd-11eb-924d-9cd76263cbd0,species,ernestii,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924",,Q100705852,,,,634588-1,wfo-0000959857,5311402,,
+87d59ba8-8fcd-11eb-924d-9cd76263cbd0,species,ernestii,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 236 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634588-1,wfo-0000959857,5311402,,
 87d5b796-8fcd-11eb-924d-9cd76263cbd0,species,euantha,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 586 1915",,,,,,634589-1,wfo-0000959858,5311377,,
 87d5d154-8fcd-11eb-924d-9cd76263cbd0,species,euglossa,Eulophia,,"(Rchb.f.) Rchb.f. ex Bateman",,,,"Bot. Mag. 92: t. 5561 1866",,,,,,,wfo-0000959859,5311313,,
 87d5ee14-8fcd-11eb-924d-9cd76263cbd0,species,eustachya,Eulophia,,"(Rchb.f.) Geerinck",,1988,,"Fl. Rwanda 4: 572 1988",,,,,,945341-1,wfo-0000959860,5311300,,
-87d607dc-8fcd-11eb-924d-9cd76263cbd0,species,evrardii,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930",,Q55757232,,,,634591-1,wfo-0000959861,5305372,,
+87d607dc-8fcd-11eb-924d-9cd76263cbd0,species,evrardii,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 337 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
+
+
+",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634591-1,wfo-0000959861,5305372,,
 87d623c0-8fcd-11eb-924d-9cd76263cbd0,species,exaltata,Eulophia,,Rchb.f.,,1857,,"Bonplandia (Hannover) 5: 38 1857",,,,,,634592-1,wfo-0000959862,5312051,,
 87d63ee6-8fcd-11eb-924d-9cd76263cbd0,variety,sarasinorum,Eulophia,exaltata,Schltr.,,1925,,"Repert. Spec. Nov. Regni Veg. 21: 195 1925",,,,,,,wfo-0000959863,5312053,,
 87d65bec-8fcd-11eb-924d-9cd76263cbd0,species,excavata,Eulophia,,Butzin,,1957,,"Willdenowia 7: 588 1957",,,,,,,wfo-0000959864,5311609,,
 87d693b4-8fcd-11eb-924d-9cd76263cbd0,species,exilis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 581 1915",,,,,,634594-1,wfo-0000959866,5312035,,
 87d6affc-8fcd-11eb-924d-9cd76263cbd0,species,explanata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,634595-1,wfo-0000959867,5311967,,
 87d6cadc-8fcd-11eb-924d-9cd76263cbd0,species,eylesii,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 194 1937",,,,,,634596-1,wfo-0000959868,5311927,,
-87d70420-8fcd-11eb-924d-9cd76263cbd0,species,faberi,Eulophia,,Rolfe,,1896,,"Bull. Misc. Inform. Kew 1896: 198 1896",,Q55786096,,,,634597-1,wfo-0000959870,5311482,,
+87d70420-8fcd-11eb-924d-9cd76263cbd0,species,faberi,Eulophia,,Rolfe,,1896,,"Bull. Misc. Inform. Kew 1896: 198 1896","New Orchids.: Decades 17-20. (1896). Bulletin of Miscellaneous Information, 1896(119), 193. https://doi.org/10.2307/4118450
+
+
+",Q55786096,DOI:10.2307/4118450,,,634597-1,wfo-0000959870,5311482,,
 87d72090-8fcd-11eb-924d-9cd76263cbd0,species,falcatiloba,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 660 2001",,,,,,20000664-1,wfo-0000959871,5311774,,
 87d739cc-8fcd-11eb-924d-9cd76263cbd0,species,faradjensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 83 1919",,,,,,634598-1,wfo-0000959872,5311936,,
 87d75448-8fcd-11eb-924d-9cd76263cbd0,species,farcta,Eulophia,,G.Will.,,1980,,"J. S. African Bot. 46: 337 1980",,,,,,634599-1,wfo-0000959873,5311822,,
-87d7705e-8fcd-11eb-924d-9cd76263cbd0,species,fernandeziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 184 1990",,Q55776633,,,,940393-1,wfo-0000959874,5311687,,
+87d7705e-8fcd-11eb-924d-9cd76263cbd0,species,fernandeziana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 184 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940393-1,wfo-0000959874,5311687,,
 87d7a6a0-8fcd-11eb-924d-9cd76263cbd0,species,filicaulis,Eulophia,,Lindl.,,1842,,"Ann. Mag. Nat. Hist. 10: 184 1842",,,,,,634600-1,wfo-0000959876,5543316,,
 87d7c0e0-8fcd-11eb-924d-9cd76263cbd0,species,filifolia,Eulophia,,"Bosser & Morat",,2001,,"Adansonia III, 23: 18 2001",,,,,,1021152-1,wfo-0000959877,5311668,,
 87d7dd32-8fcd-11eb-924d-9cd76263cbd0,species,fitzalanii,Eulophia,,F.Muell.,,1872,,"Fragm. 8: 30 1872",,,,,,,wfo-0000959878,5311840,,
 87d7f8e4-8fcd-11eb-924d-9cd76263cbd0,species,flaccida,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 3 1895",,,,,,634602-1,wfo-0000959879,5311596,,
 87d81298-8fcd-11eb-924d-9cd76263cbd0,species,flammea,Eulophia,,Kraenzl.,,1912,,"Bot. Jahrb. Syst. 48: 395 1912",,,,,,634603-1,wfo-0000959880,5311355,,
-87d830a2-8fcd-11eb-924d-9cd76263cbd0,species,flanaganii,Eulophia,,Bolus,,1905,,"Trans. S. African Philos. Soc. 16: 143 1905",,Q56148769,,,,634604-1,wfo-0000959881,5311389,,
+87d830a2-8fcd-11eb-924d-9cd76263cbd0,species,flanaganii,Eulophia,,Bolus,,1905,,"Trans. S. African Philos. Soc. 16: 143 1905","Bolus, H. (1905). CONTRIBUTIONS TO THE AFRICAN FLORA. The Transactions of the South African Philosophical Society, 16(1), 135–152. https://doi.org/10.1080/21560382.1905.9526051
+
+
+",Q56148769,DOI:10.1080/21560382.1905.9526051,,,634604-1,wfo-0000959881,5311389,,
 87d84db2-8fcd-11eb-924d-9cd76263cbd0,species,flava,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 7 1890",,,,,,634605-1,wfo-0000959882,5311458,,
 87d869be-8fcd-11eb-924d-9cd76263cbd0,species,flavopurpurea,Eulophia,,"(Rchb.f.) Rolfe",,1897,,"Fl. Trop. Afr. 7: 65 1897",,,,7d2cebd4-8fcd-11eb-924d-9cd76263cbd0,,634606-1,wfo-0000959883,5311341,,
 87d8861a-8fcd-11eb-924d-9cd76263cbd0,species,flexuosa,Eulophia,,"(Rolfe) Gilg",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,634607-1,wfo-0000959884,5307903,,
 87d89fec-8fcd-11eb-924d-9cd76263cbd0,species,florulenta,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 66 1902",,,,,,634608-1,wfo-0000959885,5311817,,
-87d8f794-8fcd-11eb-924d-9cd76263cbd0,species,foliosa,Eulophia,,"(Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 337 1882",,Q55760231,,,,634609-1,wfo-0000959888,5312071,,
-87d91404-8fcd-11eb-924d-9cd76263cbd0,species,formosana,Eulophia,,"(Rolfe) Rolfe",,1903,,"J. Linn. Soc., Bot. 36: 28 1903",,Q55760426,,,,634610-1,wfo-0000959889,5311694,,
-87d92f84-8fcd-11eb-924d-9cd76263cbd0,species,fractiflexa,Eulophia,,Summerh.,,1953,,"Kew Bull. 8: 156 1953",,Q55784833,,,,634611-1,wfo-0000959890,5311602,,
+87d8f794-8fcd-11eb-924d-9cd76263cbd0,species,foliosa,Eulophia,,"(Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 337 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
+
+
+",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634609-1,wfo-0000959888,5312071,,
+87d91404-8fcd-11eb-924d-9cd76263cbd0,species,formosana,Eulophia,,"(Rolfe) Rolfe",,1903,,"J. Linn. Soc., Bot. 36: 28 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x
+
+
+",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,634610-1,wfo-0000959889,5311694,,
+87d92f84-8fcd-11eb-924d-9cd76263cbd0,species,fractiflexa,Eulophia,,Summerh.,,1953,,"Kew Bull. 8: 156 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
+
+
+",Q55784833,DOI:10.2307/4117167,,,634611-1,wfo-0000959890,5311602,,
 87d94bae-8fcd-11eb-924d-9cd76263cbd0,species,fragrans,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 27 1895",,,,,,634612-1,wfo-0000959891,5311964,,
 87d96760-8fcd-11eb-924d-9cd76263cbd0,species,fridericii,Eulophia,,"(Rchb.f.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 131 1965",,,,db51dafa-8fcb-11eb-924d-9cd76263cbd0,,634613-1,wfo-0000959892,5311974,,
 87d98330-8fcd-11eb-924d-9cd76263cbd0,species,friesii,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 247 1916",,,,,,634614-1,wfo-0000959893,5312021,,
 87d99ffa-8fcd-11eb-924d-9cd76263cbd0,species,fusca,Eulophia,,"(Wight) Blume",,1859,,"Coll. Orchid. 182 1859",,,,7d2d5e2a-8fcd-11eb-924d-9cd76263cbd0,,634615-1,wfo-0000959894,5312141,,
-87d9bf80-8fcd-11eb-924d-9cd76263cbd0,species,galbana,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 469 1885",,Q55760268,,,,634616-1,wfo-0000959895,5306002,,
+87d9bf80-8fcd-11eb-924d-9cd76263cbd0,species,galbana,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 469 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
+
+
+",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634616-1,wfo-0000959895,5306002,,
 87d9de48-8fcd-11eb-924d-9cd76263cbd0,species,galeoloides,Eulophia,,Kraenzl.,,1898,,"Bot. Jahrb. Syst. 24: 508 1898",,,,,,634617-1,wfo-0000959896,5311832,,
 87da03b4-8fcd-11eb-924d-9cd76263cbd0,species,galpinii,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 10 1895",,,,,,634618-1,wfo-0000959897,5311398,,
 87da56ca-8fcd-11eb-924d-9cd76263cbd0,species,gastrodioides,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 337 1899",,,,,,634619-1,wfo-0000959899,5311767,,
 87da7402-8fcd-11eb-924d-9cd76263cbd0,species,geniculata,Eulophia,,"King & Pantl.",,1895,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 64(2): 337 1895",,,,,,,wfo-0000959900,5311893,,
 87da9432-8fcd-11eb-924d-9cd76263cbd0,species,gigantea,Eulophia,,"(Welw. ex Rchb.f.) N.E.Br.",,1889,,"Bull. Misc. Inform. Kew 1889: 90 1889",,,,,,,wfo-0000959901,5312028,,
-87dab368-8fcd-11eb-924d-9cd76263cbd0,species,gilletiana,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634623-1,wfo-0000959902,5311952,,
-87dad276-8fcd-11eb-924d-9cd76263cbd0,species,gladioloides,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910",,Q55781795,,,,634624-1,wfo-0000959903,5311388,,
+87dab368-8fcd-11eb-924d-9cd76263cbd0,species,gilletiana,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634623-1,wfo-0000959902,5311952,,
+87dad276-8fcd-11eb-924d-9cd76263cbd0,species,gladioloides,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
+
+
+",Q55781795,DOI:10.2307/4111720,,,634624-1,wfo-0000959903,5311388,,
 87daee5a-8fcd-11eb-924d-9cd76263cbd0,species,goetzeana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 372 1900",,,,,,634625-1,wfo-0000959904,5311833,,
 87db09e4-8fcd-11eb-924d-9cd76263cbd0,species,gonychila,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634626-1,wfo-0000959905,5311536,,
-87db264a-8fcd-11eb-924d-9cd76263cbd0,species,gracilior,Eulophia,,"(Rendle) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634627-1,wfo-0000959906,5311940,,
+87db264a-8fcd-11eb-924d-9cd76263cbd0,species,gracilior,Eulophia,,"(Rendle) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634627-1,wfo-0000959906,5311940,,
 87db4580-8fcd-11eb-924d-9cd76263cbd0,species,gracilis,Eulophia,,Lindl.,,1823,,"Bot. Reg. 9: t. 742 1823",,,,,,634628-1,wfo-0000959907,5311451,,
 87db64de-8fcd-11eb-924d-9cd76263cbd0,species,graciliscapa,Eulophia,,Schltr.,,1897,,"Bot. Jahrb. Syst. 24: 418 1897",,,,,,634629-1,wfo-0000959908,5311374,,
 87db9f08-8fcd-11eb-924d-9cd76263cbd0,species,gracillima,Eulophia,,Ridl.,,1886,,"J. Bot. 24: 292 1886",,,,,,634630-1,wfo-0000959910,5311445,,
@@ -269,12 +449,21 @@ af479264-8fd1-11eb-924d-9cd76263cbd0,species,dabia,Eulophia,,"(D.Don) M.S.Balakr
 87dbd8ce-8fcd-11eb-924d-9cd76263cbd0,species,graminea,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,,wfo-0000959912,5312157,,
 87dc097a-8fcd-11eb-924d-9cd76263cbd0,variety,kitamurae,Eulophia,graminea,"(Masam.) S.S.Ying",,1977,,"Col. Ill. Indig. Orch. Taiwan 1(2): 455 1977",,,,87e415a2-8fcd-11eb-924d-9cd76263cbd0,,887510-1,wfo-0000959913,5311906,,
 87dc69ba-8fcd-11eb-924d-9cd76263cbd0,species,grandibractea,Eulophia,,Kraenzl.,,1923,,"Mitt. Inst. Allg. Bot. Hamburg 5: 238 1923",,,,,,634633-1,wfo-0000959914,5311475,,
-87dc87c4-8fcd-11eb-924d-9cd76263cbd0,species,grandidieri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 149 1935",,Q55757322,,,,634634-1,wfo-0000959915,5312041,,
+87dc87c4-8fcd-11eb-924d-9cd76263cbd0,species,grandidieri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 149 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634634-1,wfo-0000959915,5312041,,
 87dca4ac-8fcd-11eb-924d-9cd76263cbd0,species,grandiflora,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,634635-1,wfo-0000959916,5311924,,
 87dcbfaa-8fcd-11eb-924d-9cd76263cbd0,species,granducalis,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 340 1909",,,,,,634636-1,wfo-0000959917,5311910,,
-af63c092-8fd1-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7(3): 588 1975",,Q105743545,,,,634637-1,wfo-0001223435,8017248,,
+af63c092-8fd1-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Butzin",,1975,,"Willdenowia 7(3): 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634637-1,wfo-0001223435,8017248,,
 87dcdd28-8fcd-11eb-924d-9cd76263cbd0,species,granitica,Eulophia,,"(Rchb.f.) Cufod.",,,,"Bull. Jard. Bot. État 42(3): 1615 1972",,,,,,,wfo-0000959918,5311522,,
-87dcfa88-8fcd-11eb-924d-9cd76263cbd0,species,grantii,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 148 1953",,Q55784833,,db571556-8fcb-11eb-924d-9cd76263cbd0,,634638-1,wfo-0000959919,5311732,,
+87dcfa88-8fcd-11eb-924d-9cd76263cbd0,species,grantii,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 148 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
+
+
+",Q55784833,DOI:10.2307/4117167,db571556-8fcb-11eb-924d-9cd76263cbd0,,634638-1,wfo-0000959919,5311732,,
 87dd323c-8fcd-11eb-924d-9cd76263cbd0,species,guamensis,Eulophia,,Ames,,1914,,"Philipp. J. Sci., C 9: 12 1914",,,,,,634639-1,wfo-0000959921,5311753,,
 c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"Bot. Reg. 8: t. 686 1823",,,,,,,wfo-0001088132,7383573,,
 87dd4ca4-8fcd-11eb-924d-9cd76263cbd0,species,guineensis,Eulophia,,Lindl.,,1823,,"Bot. Reg. 8: t. 686 1823",,,,,,634640-1,wfo-0000959922,5311862,,
@@ -284,7 +473,10 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87ddbfd6-8fcd-11eb-924d-9cd76263cbd0,species,gumbariensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 117 1919",,,,,,634641-1,wfo-0000959926,5311788,,
 87dddd72-8fcd-11eb-924d-9cd76263cbd0,species,gusukumae,Eulophia,,Masam.,,1934,,"Trans. Nat. Hist. Soc. Taiwan 24: 208 1934",,,,,,634642-1,wfo-0000959927,5312161,,
 87ddf7f8-8fcd-11eb-924d-9cd76263cbd0,species,hastata,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634643-1,wfo-0000959928,5305369,,
-87de14cc-8fcd-11eb-924d-9cd76263cbd0,species,haygarthii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910",,Q55782219,,,,634644-1,wfo-0000959929,5312000,,
+87de14cc-8fcd-11eb-924d-9cd76263cbd0,species,haygarthii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
+
+
+",Q55782219,DOI:10.2307/4113249,,,634644-1,wfo-0000959929,5312000,,
 87de2ef8-8fcd-11eb-924d-9cd76263cbd0,species,helleborina,Eulophia,,Hook.f.,,,,"Bot. Mag. 96: t. 5875 1870",,,,,,634645-1,wfo-0000959930,5311291,,
 87deb0e4-8fcd-11eb-924d-9cd76263cbd0,species,hemileuca,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634646-1,wfo-0000959932,5311490,,
 87decd90-8fcd-11eb-924d-9cd76263cbd0,species,herbacea,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634647-1,wfo-0000959933,5311469,,
@@ -293,20 +485,35 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87df1fc0-8fcd-11eb-924d-9cd76263cbd0,variety,inaequalis,Eulophia,hians,"(Schltr.) S.Thomas",,1998,,"Lindleyana 13: 183 1998",,,,,,1004906-1,wfo-0000959936,5311408,,
 87df3c26-8fcd-11eb-924d-9cd76263cbd0,variety,nutans,Eulophia,hians,"(Sond.) S.Thomas",,1998,,"Lindleyana 13: 183 1998",,,,87f32420-8fcd-11eb-924d-9cd76263cbd0,,1004905-1,wfo-0000959937,5311387,,
 87df567a-8fcd-11eb-924d-9cd76263cbd0,species,hildebrandii,Eulophia,,Schltr.,,1919,,"Repert. Spec. Nov. Regni Veg. Beih. 4: 262 1919",,,,,,634650-1,wfo-0000959938,5312139,,
-87df72e0-8fcd-11eb-924d-9cd76263cbd0,species,hirschbergii,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958",,Q55785005,,,,634651-1,wfo-0000959939,5312056,,
+87df72e0-8fcd-11eb-924d-9cd76263cbd0,species,hirschbergii,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634651-1,wfo-0000959939,5312056,,
 87dfa74c-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,T.P.Lin,,1987,,"Native Orchids Taiwan 3: 68 1987",,,,,,934110-1,wfo-0000959941,7615066,,
-87df8c8a-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,"J.Joseph & Vajr.",,1975,,"Bull. Bot. Surv. India 17: 192 1975 publ. 1978",,Q101074629,,,,634652-1,wfo-0000959940,5319562,,
+87df8c8a-8fcd-11eb-924d-9cd76263cbd0,species,hirsuta,Eulophia,,"J.Joseph & Vajr.",,1975,,"Bull. Bot. Surv. India 17: 192 1975 publ. 1978","Joseph, J., & Vajravelu, E. (1975). Eulophia Hirsuta Joseph et Vajravelu (Orchidaceae) - a New Species from South India. Bulletin of the Botanical Survey of India, 17(1-4), 192-194. https://doi.org/10.20324/nelumbo/v17/1975/75827
+
+
+",Q101074629,DOI:10.20324/nelumbo/v17/1975/75827,,,634652-1,wfo-0000959940,5319562,,
 87dfe036-8fcd-11eb-924d-9cd76263cbd0,species,hockii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 120 1919",,,,,,634653-1,wfo-0000959943,5311819,,
 87dffbde-8fcd-11eb-924d-9cd76263cbd0,species,holochila,Eulophia,,"Collett & Hemsl.",,1890,,"J. Linn. Soc., Bot. 28: 132 1890",,,,,,634654-1,wfo-0000959944,5312149,,
 87e01916-8fcd-11eb-924d-9cd76263cbd0,species,hologlossa,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 171 1913",,,,,,634655-1,wfo-0000959945,5311930,,
 87e038a6-8fcd-11eb-924d-9cd76263cbd0,species,holstiana,Eulophia,,Kraenzl.,,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,,wfo-0000959946,5311370,,
 87e05494-8fcd-11eb-924d-9cd76263cbd0,species,holtzei,Eulophia,,F.Muell.,,1889,,"Victorian Naturalist 6: 55 1889",,,,,,634657-1,wfo-0000959947,5319578,,
 87e06f10-8fcd-11eb-924d-9cd76263cbd0,species,holubii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634658-1,wfo-0000959948,5311859,,
-87e08a68-8fcd-11eb-924d-9cd76263cbd0,species,homblei,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634659-1,wfo-0000959949,5311496,,
+87e08a68-8fcd-11eb-924d-9cd76263cbd0,species,homblei,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634659-1,wfo-0000959949,5311496,,
 87e0a55c-8fcd-11eb-924d-9cd76263cbd0,species,hormusjii,Eulophia,,Duthie,,1906,,"Ann. Roy. Bot. Gard. (Calcutta) 9(2): 125 1906",,,,,,634660-1,wfo-0000959950,5311486,,
 87e0bfb0-8fcd-11eb-924d-9cd76263cbd0,species,horsfallii,Eulophia,,"(Bateman) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,db5c7064-8fcb-11eb-924d-9cd76263cbd0,,634661-1,wfo-0000959951,5311649,,
-87e0dcde-8fcd-11eb-924d-9cd76263cbd0,species,huillensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634662-1,wfo-0000959952,5311643,,
-87e11690-8fcd-11eb-924d-9cd76263cbd0,species,humbertii,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 588 1975",,Q105743545,,,,634663-1,wfo-0000959954,5323765,,
+87e0dcde-8fcd-11eb-924d-9cd76263cbd0,species,huillensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634662-1,wfo-0000959952,5311643,,
+87e11690-8fcd-11eb-924d-9cd76263cbd0,species,humbertii,Eulophia,,"(H.Perrier) Butzin",,1975,,"Willdenowia 7: 588 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634663-1,wfo-0000959954,5323765,,
 87e14dc2-8fcd-11eb-924d-9cd76263cbd0,species,humilis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 165 1895",,,,,,634664-1,wfo-0000959956,7376289,,
 87e1308a-8fcd-11eb-924d-9cd76263cbd0,species,humilis,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 337 1899",,,,,,634665-1,wfo-0000959955,5311593,,
 87e1699c-8fcd-11eb-924d-9cd76263cbd0,species,huttonii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 52 1912",,,,,,634666-1,wfo-0000959957,5311567,,
@@ -318,40 +525,76 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87e21068-8fcd-11eb-924d-9cd76263cbd0,species,inconspicua,Eulophia,,Griff.,,1851,,"Not. Pl. Asiat. 3: 349 1851",,,,,,634673-1,wfo-0000959963,5312159,,
 87e250b4-8fcd-11eb-924d-9cd76263cbd0,species,involuta,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 442 1936",,,,,,634674-1,wfo-0000959965,5311328,,
 87e26b30-8fcd-11eb-924d-9cd76263cbd0,species,inyangensis,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 195 1937",,,,,,634675-1,wfo-0000959966,5311861,,
-87e286ce-8fcd-11eb-924d-9cd76263cbd0,species,ischna,Eulophia,,Summerh.,,1957,,"Kew Bull. 12: 125 1957",,Q55779620,,,,634676-1,wfo-0000959967,5311880,,
+87e286ce-8fcd-11eb-924d-9cd76263cbd0,species,ischna,Eulophia,,Summerh.,,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113
+
+
+",Q55779620,DOI:10.2307/4109113,,,634676-1,wfo-0000959967,5311880,,
 87e2a0be-8fcd-11eb-924d-9cd76263cbd0,species,javanica,Eulophia,,J.J.Sm.,,1921,,"Bull. Jard. Bot. Buitenzorg III, 3: 260 1921",,,,,,634677-1,wfo-0000959968,5311979,,
 87e2bc48-8fcd-11eb-924d-9cd76263cbd0,species,johnstonii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 66 1897",,,,,,634678-1,wfo-0000959969,5311373,,
 87e2d606-8fcd-11eb-924d-9cd76263cbd0,species,jumelleana,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 172 1913",,,,,,634679-1,wfo-0000959970,5311937,,
-87e2f3a2-8fcd-11eb-924d-9cd76263cbd0,species,juncifolia,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958",,Q55785005,,,,634680-1,wfo-0000959971,5311869,,
+87e2f3a2-8fcd-11eb-924d-9cd76263cbd0,species,juncifolia,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 78 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634680-1,wfo-0000959971,5311869,,
 87e3122e-8fcd-11eb-924d-9cd76263cbd0,species,junodiana,Eulophia,,Kraenzl.,,1897,,"Bull. Herb. Boissier 5: 634 1897",,,,,,634681-1,wfo-0000959972,5311436,,
 87e32e6c-8fcd-11eb-924d-9cd76263cbd0,species,kamarupa,Eulophia,,Sud.Chowdhury,,1993,,"J. Orchid Soc. India 7: 49 1993",,,,,,1008706-1,wfo-0000959973,5311814,,
 87e34b0e-8fcd-11eb-924d-9cd76263cbd0,species,katangensis,Eulophia,,"(De Wild.) De Wild.",,1919,,"Bull. Jard. Bot. État 6: 121 1919",,,,,,634682-1,wfo-0000959974,5311768,,
-87e38204-8fcd-11eb-924d-9cd76263cbd0,species,keiliana,Eulophia,,"(Kraenzl.) Butzin",,1973,,"Willdenowia 7: 588 1973",,Q105743545,,90a13bfc-8fcd-11eb-924d-9cd76263cbd0,,634683-1,wfo-0000959976,5311650,,
-87e39e74-8fcd-11eb-924d-9cd76263cbd0,species,keithii,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 32: 333 1896",,Q55760377,,,,634684-1,wfo-0000959977,5311303,,
-87e3bb0c-8fcd-11eb-924d-9cd76263cbd0,species,keniensis,Eulophia,,Schltr.,,1924,,"Notizbl. Bot. Gart. Berlin-Dahlem 9: 21 1924",,Q55777118,,,,634685-1,wfo-0000959978,5311415,,
+87e38204-8fcd-11eb-924d-9cd76263cbd0,species,keiliana,Eulophia,,"(Kraenzl.) Butzin",,1973,,"Willdenowia 7: 588 1973","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,90a13bfc-8fcd-11eb-924d-9cd76263cbd0,,634683-1,wfo-0000959976,5311650,,
+87e39e74-8fcd-11eb-924d-9cd76263cbd0,species,keithii,Eulophia,,Ridl.,,1896,,"J. Linn. Soc., Bot. 32: 333 1896","Ridley, H. (1896). The Orchideae and Apostasiaceae of the Malay Peninsula. Transactions of the Linnean Society of London: Botany, 32(220-227), 213–416. https://doi.org/10.1111/j.1095-8339.1896.tb00698.x
+
+
+",Q55760377,DOI:10.1111/j.1095-8339.1896.tb00698.x,,,634684-1,wfo-0000959977,5311303,,
+87e3bb0c-8fcd-11eb-924d-9cd76263cbd0,species,keniensis,Eulophia,,Schltr.,,1924,,"Notizbl. Bot. Gart. Berlin-Dahlem 9: 21 1924","Fries, R. E., Fries, T. C. E., & Schlechter, R. (1924). Beitrage zur Kenntnis der Flora des Kenia, Mt. Aberdare und Mt. Elgon. V. Notizblatt Des Königl. Botanischen Gartens Und Museums Zu Berlin, 9(81), 16. https://doi.org/10.2307/3994426
+
+
+",Q55777118,DOI:10.2307/3994426,,,634685-1,wfo-0000959978,5311415,,
 87e3d52e-8fcd-11eb-924d-9cd76263cbd0,species,kirkii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 58 1897",,,,,,634686-1,wfo-0000959979,5312030,,
 87e3f22a-8fcd-11eb-924d-9cd76263cbd0,species,kisanfuensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 93 1919",,,,,,634687-1,wfo-0000959980,5311983,,
 87e415a2-8fcd-11eb-924d-9cd76263cbd0,species,kitamurae,Eulophia,,Masam.,,1932,,"J. Soc. Trop. Agric. 4: 192 1932",,,,,,634688-1,wfo-0000959981,5311907,,
-87e43186-8fcd-11eb-924d-9cd76263cbd0,species,kondensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634689-1,wfo-0000959982,5311631,,
-87e44d60-8fcd-11eb-924d-9cd76263cbd0,species,krebsii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889",,Q55760323,,db5ef91a-8fcb-11eb-924d-9cd76263cbd0,,634690-1,wfo-0000959983,5311742,,
+87e43186-8fcd-11eb-924d-9cd76263cbd0,species,kondensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634689-1,wfo-0000959982,5311631,,
+87e44d60-8fcd-11eb-924d-9cd76263cbd0,species,krebsii,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,db5ef91a-8fcb-11eb-924d-9cd76263cbd0,,634690-1,wfo-0000959983,5311742,,
 87e466d8-8fcd-11eb-924d-9cd76263cbd0,species,kyimbilae,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 584 1915",,,,,,634691-1,wfo-0000959984,5311418,,
 87e48078-8fcd-11eb-924d-9cd76263cbd0,species,lachnocheila,Eulophia,,Hook.f.,,1890,,"Fl. Brit. India 6: 2 1890",,,,,,634692-1,wfo-0000959985,5311334,,
-87e4ba20-8fcd-11eb-924d-9cd76263cbd0,species,lambii,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914",,Q55787805,,,,634693-1,wfo-0000959987,5312031,,
-87e4d3de-8fcd-11eb-924d-9cd76263cbd0,species,lambinoniana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 185 1990",,Q55776633,,,,940394-1,wfo-0000959988,5311901,,
+87e4ba20-8fcd-11eb-924d-9cd76263cbd0,species,lambii,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503
+
+
+",Q55787805,DOI:10.2307/4119503,,,634693-1,wfo-0000959987,5312031,,
+87e4d3de-8fcd-11eb-924d-9cd76263cbd0,species,lambinoniana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 185 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940394-1,wfo-0000959988,5311901,,
 87e4efcc-8fcd-11eb-924d-9cd76263cbd0,species,lamellata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 184 1833",,,,,,634694-1,wfo-0000959989,5312507,,
-87e5094e-8fcd-11eb-924d-9cd76263cbd0,species,lanceata,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 156 1935",,Q55757322,,,,634695-1,wfo-0000959990,5323784,,
+87e5094e-8fcd-11eb-924d-9cd76263cbd0,species,lanceata,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 156 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634695-1,wfo-0000959990,5323784,,
 87e5258c-8fcd-11eb-924d-9cd76263cbd0,species,lanceolata,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634696-1,wfo-0000959991,5311294,,
 87e53f5e-8fcd-11eb-924d-9cd76263cbd0,species,lata,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634697-1,wfo-0000959992,5311356,,
 87e55c1e-8fcd-11eb-924d-9cd76263cbd0,species,latifolia,Eulophia,,Rolfe,,1891,,"Bol. Soc. Brot. 9: 139 1891",,,,,,634698-1,wfo-0000959993,5323766,,
 87e57a6e-8fcd-11eb-924d-9cd76263cbd0,species,latilabris,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634699-1,wfo-0000959994,5311950,,
 87e59a12-8fcd-11eb-924d-9cd76263cbd0,species,latipetala,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 41 1912",,,,,,634700-1,wfo-0000959995,5312113,,
 87e5b524-8fcd-11eb-924d-9cd76263cbd0,species,laurentiana,Eulophia,,Kraenzl.,,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 60 1899",,,,,,,wfo-0000959996,5311456,,
-87e606aa-8fcd-11eb-924d-9cd76263cbd0,species,laurentii,Eulophia,,"(De Wild.) Summerh.",,1960,,"Kew Bull. 14: 139 1960",,Q55784110,,,,634702-1,wfo-0000959999,5311829,,
+87e606aa-8fcd-11eb-924d-9cd76263cbd0,species,laurentii,Eulophia,,"(De Wild.) Summerh.",,1960,,"Kew Bull. 14: 139 1960","Summerhayes, V. S. (1960). African Orchids: XXVII. Kew Bulletin, 14(1), 126. https://doi.org/10.2307/4115580
+
+
+",Q55784110,DOI:10.2307/4115580,,,634702-1,wfo-0000959999,5311829,,
 87e62356-8fcd-11eb-924d-9cd76263cbd0,species,laxiflora,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 4 1895",,,,,,634703-1,wfo-0000960000,5311401,,
 87e63f94-8fcd-11eb-924d-9cd76263cbd0,species,leachii,Eulophia,,"Greatrex ex A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 161 1965",,,,,,634704-1,wfo-0000960001,5311766,,
 87e65a06-8fcd-11eb-924d-9cd76263cbd0,species,ledermannii,Eulophia,,Kraenzl.,,1912,,"Bot. Jahrb. Syst. 48: 394 1912",,,,,,634705-1,wfo-0000960002,5312044,,
 87e6764e-8fcd-11eb-924d-9cd76263cbd0,species,ledienii,Eulophia,,"Stein ex N.E.Br.",,1889,,"Bull. Misc. Inform. Kew 1889: 90 1889",,,,,,,wfo-0000960003,5323738,,
-87e692e6-8fcd-11eb-924d-9cd76263cbd0,species,lejolyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990",,Q55776633,,,,940395-1,wfo-0000960004,5311621,,
+87e692e6-8fcd-11eb-924d-9cd76263cbd0,species,lejolyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940395-1,wfo-0000960004,5311621,,
 545f6732-8fcc-11eb-924d-9cd76263cbd0,species,lenbrassii,Eulophia,,Ormerod,,2003,,"Oasis 2(4): 4 2003",,,,,,70028093-1,wfo-0000416216,5311427,,
 87e6aef2-8fcd-11eb-924d-9cd76263cbd0,species,leonensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 51 1897",,,,,,634707-1,wfo-0000960005,5311589,,
 87e6c8ec-8fcd-11eb-924d-9cd76263cbd0,species,leontoglossa,Eulophia,,Rchb.f.,,1881,,"Flora 64: 329 1881",,,,,,634708-1,wfo-0000960006,5311557,,
@@ -368,10 +611,19 @@ c3a4be7a-8fcd-11eb-924d-9cd76263cbd0,species,guineense,Eulophia,,Lindl.,,1823,,"
 87e82296-8fcd-11eb-924d-9cd76263cbd0,species,lisowskii,Eulophia,,Szlach.,,1993,,"Fragm. Florist. Geobot. 38: 461 1993",,,,,,976600-1,wfo-0000960018,5312046,,
 87e83ee8-8fcd-11eb-924d-9cd76263cbd0,species,lissochiloides,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 203 1837",,,,,,634717-1,wfo-0000960019,5311438,,
 87e891e0-8fcd-11eb-924d-9cd76263cbd0,species,litoralis,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 338 1899",,,,,,634718-1,wfo-0000960021,5311970,,
-87e8b51c-8fcd-11eb-924d-9cd76263cbd0,species,livingstoneana,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 132 1947 publ. 1948",,Q43263417,,,,634719-1,wfo-0000960022,5311933,,
+87e8b51c-8fcd-11eb-924d-9cd76263cbd0,species,livingstoneana,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 132 1947 publ. 1948","Summerhayes, V. S. (1947). African Orchids: XVII. Kew Bulletin, 2(2), 123–133. https://doi.org/10.2307/4109211
+
+
+",Q43263417,DOI:10.2307/4109211,,,634719-1,wfo-0000960022,5311933,,
 ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.) Schltr.",,1913,,"Ann. Mus. Colon. Marseille, sér. 3, 1: 172 1913",,,,,,634720-1,wfo-0001243813,5543290,,
-87e8e4b0-8fcd-11eb-924d-9cd76263cbd0,species,lokobensis,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 153 1935",,Q55757322,,,,634721-1,wfo-0000960023,5323773,,
-87e90d46-8fcd-11eb-924d-9cd76263cbd0,species,lomamiensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634722-1,wfo-0000960024,5311951,,
+87e8e4b0-8fcd-11eb-924d-9cd76263cbd0,species,lokobensis,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 153 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634721-1,wfo-0000960023,5323773,,
+87e90d46-8fcd-11eb-924d-9cd76263cbd0,species,lomamiensis,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634722-1,wfo-0000960024,5311951,,
 87e934ce-8fcd-11eb-924d-9cd76263cbd0,species,lonchophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 542 1885",,,,,,634723-1,wfo-0000960025,5323732,,
 87e962c8-8fcd-11eb-924d-9cd76263cbd0,species,longibracteata,Eulophia,,"(Lindl.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 22 1894",,,,,,634725-1,wfo-0000960026,5311680,,
 87e98a0a-8fcd-11eb-924d-9cd76263cbd0,species,longicollis,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,634726-1,wfo-0000960027,5308352,,
@@ -379,10 +631,22 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87e9c772-8fcd-11eb-924d-9cd76263cbd0,species,longifolia,Eulophia,,"(Kunth) Schltr.",,1914,,"Orchideen 347 1914",,,,,,99296-2,wfo-0000960029,5311797,,
 309c1aba-8fcd-11eb-924d-9cd76263cbd0,variety,amazonica,Eulophia,longifolia,"(Barb.Rodr.) Cogn.",,1942,,"Fl. Bras. 12(6): 4 1942",,,,,,99297-2,wfo-0000795139,7964353,,
 1cc480be-8fcc-11eb-924d-9cd76263cbd0,variety,flavescens,Eulophia,longifolia,Schltr.,,1922,,"Anexos Mem. Inst. Butantan, Secc. Bot. 1(4): 62 1922",,,,,,99298-2,wfo-0000336473,5311806,,
-87e9e824-8fcd-11eb-924d-9cd76263cbd0,species,longilobata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634730-1,wfo-0000960030,5311957,,
-87ea037c-8fcd-11eb-924d-9cd76263cbd0,species,longipedunculata,Eulophia,,Rendle,,1895,,"J. Linn. Soc., Bot. 30: 383 1895",,Q55760371,,,,634724-1,wfo-0000960031,5311789,,
-87ea1ed4-8fcd-11eb-924d-9cd76263cbd0,species,longipes,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910",,Q55781794,,,,634731-1,wfo-0000960032,5311416,,
-87ea3932-8fcd-11eb-924d-9cd76263cbd0,species,longisepala,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 43 1894",,Q54554200,,,,634732-1,wfo-0000960033,5311541,,
+87e9e824-8fcd-11eb-924d-9cd76263cbd0,species,longilobata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634730-1,wfo-0000960030,5311957,,
+87ea037c-8fcd-11eb-924d-9cd76263cbd0,species,longipedunculata,Eulophia,,Rendle,,1895,,"J. Linn. Soc., Bot. 30: 383 1895","Rendle, A. B. (1895). A Contribution to the Flora of Eastern Tropical Africa. Transactions of the Linnean Society of London: Botany, 30(210), 373–435. https://doi.org/10.1111/j.1095-8339.1894.tb02417.x
+
+
+",Q55760371,DOI:10.1111/j.1095-8339.1894.tb02417.x,,,634724-1,wfo-0000960031,5311789,,
+87ea1ed4-8fcd-11eb-924d-9cd76263cbd0,species,longipes,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 280 1910","Decades Kewenses. Plantarum Novarum in Herbario Horti Regii, Conservatarum. Decas LVIII. (1910). Bulletin of Miscellaneous Information, 1910(8), 275. https://doi.org/10.2307/4111719
+
+
+",Q55781794,DOI:10.2307/4111719,,,634731-1,wfo-0000960032,5311416,,
+87ea3932-8fcd-11eb-924d-9cd76263cbd0,species,longisepala,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 43 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
+
+
+",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634732-1,wfo-0000960033,5311541,,
 87ea5638-8fcd-11eb-924d-9cd76263cbd0,species,lubbersiana,Eulophia,,"De Wild. & Laurent",,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 135 1899",,,,,,,wfo-0000960034,5323751,,
 87ea72b2-8fcd-11eb-924d-9cd76263cbd0,species,lujae,Eulophia,,"De Wild.",,1904,,"Pl. Nov. Horti Then. t. 17 1904",,,,,,634735-1,wfo-0000960035,5311913,,
 87ea8cac-8fcd-11eb-924d-9cd76263cbd0,species,lujaeana,Eulophia,,Kraenzl.,,1899,,"Bull. Soc. Roy. Bot. Belgique Compt.-Rend. 38: 217 1899",,,,,,,wfo-0000960036,5311446,,
@@ -390,14 +654,20 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87eac26c-8fcd-11eb-924d-9cd76263cbd0,species,lurida,Eulophia,,"(Sw.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634737-1,wfo-0000960038,5308351,,
 87eade0a-8fcd-11eb-924d-9cd76263cbd0,species,lutea,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,634738-1,wfo-0000960039,5311441,,
 87eafaca-8fcd-11eb-924d-9cd76263cbd0,species,lutea,Eulophia,,Blume,,1859,,"Coll. Orchid. 181 1859",,,,,,634739-1,wfo-0000960040,7934610,,
-87eb16cc-8fcd-11eb-924d-9cd76263cbd0,species,macaulayi,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927",,Q55778720,,,,634740-1,wfo-0000960041,5312050,,
+87eb16cc-8fcd-11eb-924d-9cd76263cbd0,species,macaulayi,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
+
+
+",Q55778720,DOI:10.2307/4107556,,,634740-1,wfo-0000960041,5312050,,
 87eb3454-8fcd-11eb-924d-9cd76263cbd0,species,macgregorii,Eulophia,,Ames,,1914,,"Philipp. J. Sci., C 9: 12 1914",,,,,,634741-1,wfo-0000960042,5312151,,
 87eb55e2-8fcd-11eb-924d-9cd76263cbd0,species,mackaiana,Eulophia,,Lindl.,,,,"Edwards's Bot. Reg. 17: t. 1433 1831",,,,,,634742-1,wfo-0000960043,5322761,,
 87eb70cc-8fcd-11eb-924d-9cd76263cbd0,species,mackenii,Eulophia,,"Rolfe ex Hemsl.",,1892,,"Gard. Chron. III, 12: 583 1892",,,,,,,wfo-0000960044,5323740,,
 87eb8c10-8fcd-11eb-924d-9cd76263cbd0,species,mackinnonii,Eulophia,,Duthie,,1902,,"J. Asiat. Soc. Bengal, Pt. 2, Nat. Hist. 71: 40 1902",,,,,,634744-1,wfo-0000960045,5311966,,
 87eba894-8fcd-11eb-924d-9cd76263cbd0,species,macowanii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 38 1912",,,,,,634745-1,wfo-0000960046,5311925,,
 87ebe106-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 217 1903",,,,,,634747-1,wfo-0000960048,7988890,,
-87ebc450-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Ridl.,,1886,,"J. Linn. Soc., Bot. 22: 120 1886",,Q55760282,,,,634746-1,wfo-0000960047,5311873,,
+87ebc450-8fcd-11eb-924d-9cd76263cbd0,species,macra,Eulophia,,Ridl.,,1886,,"J. Linn. Soc., Bot. 22: 120 1886","Ridley, H. N. (1886). On Dr. Fox’s Collection of Orchids from Madagascar, along with some obtained by the Rev. R. Baron, F.L.S., from the same island. Transactions of the Linnean Society of London: Botany, 22(142), 116–127. https://doi.org/10.1111/j.1095-8339.1886.tb00646.x
+
+
+",Q55760282,DOI:10.1111/j.1095-8339.1886.tb00646.x,,,634746-1,wfo-0000960047,5311873,,
 87ebfb82-8fcd-11eb-924d-9cd76263cbd0,species,macrantha,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 62 1897",,,,,,634748-1,wfo-0000960049,5311815,,
 87ec1860-8fcd-11eb-924d-9cd76263cbd0,species,macrobulbon,Eulophia,,"(E.C.Parish & Rchb.f.) Hook.f.",,1890,,"Fl. Brit. India 6: 7 1890",,,,7d2e5ca8-8fcd-11eb-924d-9cd76263cbd0,,634749-1,wfo-0000960050,5311771,,
 87ec355c-8fcd-11eb-924d-9cd76263cbd0,species,macrorhiza,Eulophia,,Blume,,1859,,"Coll. Orchid. 183 1859",,,,,,634750-1,wfo-0000960051,5311697,,
@@ -406,14 +676,26 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87ec87be-8fcd-11eb-924d-9cd76263cbd0,species,macrostachya,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 183 1833",,,,,,634752-1,wfo-0000960054,5311756,,
 87eca5e6-8fcd-11eb-924d-9cd76263cbd0,species,maculata,Eulophia,,"(Lindl.) Rchb.f.",,1863,,"Ann. Bot. Syst. 6: 647 1863",,,,,,634753-1,wfo-0000960055,5323741,,
 87ecc292-8fcd-11eb-924d-9cd76263cbd0,species,madagascariensis,Eulophia,,Kraenzl.,,1882,,"Abh. Naturwiss. Vereins Bremen 7: 255 1882",,,,,,634754-1,wfo-0000960056,5311392,,
-87ece0c4-8fcd-11eb-924d-9cd76263cbd0,species,maesta,Eulophia,,"(Merxm.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634755-1,wfo-0000960057,5311607,,
+87ece0c4-8fcd-11eb-924d-9cd76263cbd0,species,maesta,Eulophia,,"(Merxm.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634755-1,wfo-0000960057,5311607,,
 87ed0144-8fcd-11eb-924d-9cd76263cbd0,species,magnicristata,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 620 2001",,,,,,20000661-1,wfo-0000960058,5311646,,
 87ed1df0-8fcd-11eb-924d-9cd76263cbd0,species,mahonii,Eulophia,,"(Rolfe) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,,,634756-1,wfo-0000960059,5311666,,
-87ed3a60-8fcd-11eb-924d-9cd76263cbd0,species,malangana,Eulophia,,"(Rchb.f.) Summerh.",,1956,,"Kew Bull. 11: 232 1956",,Q55779609,,,,634757-1,wfo-0000960060,5311337,,
+87ed3a60-8fcd-11eb-924d-9cd76263cbd0,species,malangana,Eulophia,,"(Rchb.f.) Summerh.",,1956,,"Kew Bull. 11: 232 1956","Summerhayes, V. S. (1956). African Orchids: XXIII. Kew Bulletin, 11(2), 217. https://doi.org/10.2307/4109030
+
+
+",Q55779609,DOI:10.2307/4109030,,,634757-1,wfo-0000960060,5311337,,
 87ed75d4-8fcd-11eb-924d-9cd76263cbd0,species,manganjensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 67 1897",,,,,,634758-1,wfo-0000960062,5311741,,
-87ed9208-8fcd-11eb-924d-9cd76263cbd0,species,mangenotiana,Eulophia,,"Bosser & Veyret",,1970,,"Adansonia n.s., 10: 216 1970",,Q58838388,,,,634759-1,wfo-0000960063,5312115,,
+87ed9208-8fcd-11eb-924d-9cd76263cbd0,species,mangenotiana,Eulophia,,"Bosser & Veyret",,1970,,"Adansonia n.s., 10: 216 1970","Bosser, J., & Veyret, Y. (1970). Contribution à l’étude des Orchidaceae de Madagascar. XIII. Sur un Cynorkis et un Eulophia nouveaux. Adansonia Nouvelle série, 10(2), 213-217.
+
+
+",Q58838388,,,,634759-1,wfo-0000960063,5312115,,
 87edb008-8fcd-11eb-924d-9cd76263cbd0,species,mannii,Eulophia,,"(Rchb.f.) Hook.f.",,1890,,"Fl. Brit. India 6: 4 1890",,,,,,634760-1,wfo-0000960064,5312069,,
-87edcb60-8fcd-11eb-924d-9cd76263cbd0,species,massiei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930",,Q55757232,,,,634761-1,wfo-0000960065,5311895,,
+87edcb60-8fcd-11eb-924d-9cd76263cbd0,species,massiei,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
+
+
+",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634761-1,wfo-0000960065,5311895,,
 87ede7d0-8fcd-11eb-924d-9cd76263cbd0,species,massokoensis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 580 1915",,,,,,634762-1,wfo-0000960066,5312020,,
 87ee027e-8fcd-11eb-924d-9cd76263cbd0,species,maxillaris,Eulophia,,"(Lodd.) G.Don",,1850,,"Suppl. Hort. Brit. 588 1850",,,,,,,wfo-0000960067,5322762,,
 87ee1f0c-8fcd-11eb-924d-9cd76263cbd0,species,mechowii,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 23 1894",,,,,,634764-1,wfo-0000960068,5311909,,
@@ -423,50 +705,98 @@ ba76619c-8fd1-11eb-924d-9cd76263cbd0,species,livingstoniana,Eulophia,,"(Rchb.f.)
 87eea990-8fcd-11eb-924d-9cd76263cbd0,species,menelikii,Eulophia,,Pax,,1907,,"Bot. Jahrb. Syst. 39: 612 1907",,,,,,634768-1,wfo-0000960073,5311301,,
 87eec2cc-8fcd-11eb-924d-9cd76263cbd0,species,merrillii,Eulophia,,Ames,,1915,,"Orchidaceae 5: 104 1915",,,,,,634769-1,wfo-0000960074,5311853,,
 87eedd98-8fcd-11eb-924d-9cd76263cbd0,species,micrantha,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 184 1833",,,,,,634770-1,wfo-0000960075,5312520,,
-87eef968-8fcd-11eb-924d-9cd76263cbd0,species,microceras,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 154 1953",,Q55784833,,db63d552-8fcb-11eb-924d-9cd76263cbd0,,634771-1,wfo-0000960076,5311608,,
+87eef968-8fcd-11eb-924d-9cd76263cbd0,species,microceras,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 154 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
+
+
+",Q55784833,DOI:10.2307/4117167,db63d552-8fcb-11eb-924d-9cd76263cbd0,,634771-1,wfo-0000960076,5311608,,
 87ef13bc-8fcd-11eb-924d-9cd76263cbd0,species,microdactyla,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 389 1914",,,,,,634772-1,wfo-0000960077,5311440,,
 87ef49ea-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 372 1900",,,,,,634774-1,wfo-0000960079,7373826,,
-87ef2dca-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894",,Q54554200,,,,634773-1,wfo-0000960078,5311919,,
+87ef2dca-8fcd-11eb-924d-9cd76263cbd0,species,milanjiana,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
+
+
+",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634773-1,wfo-0000960078,5311919,,
 87ef6506-8fcd-11eb-924d-9cd76263cbd0,species,mildbraedii,Eulophia,,Kraenzl.,,1909,,"Bot. Jahrb. Syst. 43: 339 1909",,,,,,634775-1,wfo-0000960080,5323768,,
 87ef7f1e-8fcd-11eb-924d-9cd76263cbd0,species,millsonii,Eulophia,,"(Rolfe) Summerh.",,1936,,"Fl. W. Trop. Afr. 2: 446 1936",,,,db644de8-8fcb-11eb-924d-9cd76263cbd0,,634776-1,wfo-0000960081,5311352,,
 87ef98d2-8fcd-11eb-924d-9cd76263cbd0,species,milnei,Eulophia,,Rchb.f.,,1881,,"Otia Bot. Hamburg. 116 1881",,,,,,634777-1,wfo-0000960082,5311439,,
 87efcf46-8fcd-11eb-924d-9cd76263cbd0,variety,norlindhii,Eulophia,milnei,"(Summerh.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 684 1992",,,,87f2d40c-8fcd-11eb-924d-9cd76263cbd0,,967485-1,wfo-0000960084,5312036,,
 87efebe8-8fcd-11eb-924d-9cd76263cbd0,species,minimiflora,Eulophia,,Kraenzl.,,1928,,"Notul. Syst. (Paris) 4: 137 1928",,,,,,634778-1,wfo-0000960085,5314462,,
 87f00772-8fcd-11eb-924d-9cd76263cbd0,species,missionis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 168 1895",,,,,,634779-1,wfo-0000960086,5311363,,
-87f02158-8fcd-11eb-924d-9cd76263cbd0,species,monantha,Eulophia,,W.W.Sm.,,1921,,"Notes Roy. Bot. Gard. Edinburgh 13: 203 1921",,Q102419243,,,,634780-1,wfo-0000960087,5312107,,
+87f02158-8fcd-11eb-924d-9cd76263cbd0,species,monantha,Eulophia,,W.W.Sm.,,1921,,"Notes Roy. Bot. Gard. Edinburgh 13: 203 1921","Smith, W. W. (1921). New orchids from Yunnan and northern Burma. Notes from the Royal Botanic Garden, Edinburgh, 13(63-64), 189-222.
+
+
+",Q102419243,,,,634780-1,wfo-0000960087,5312107,,
 87f03d96-8fcd-11eb-924d-9cd76263cbd0,species,monile,Eulophia,,Rchb.f.,,1867,,"Flora 50: 105 1867",,,,,,634781-1,wfo-0000960088,5312034,,
 54615290-8fcc-11eb-924d-9cd76263cbd0,variety,brevipetala,Eulophia,monile,"(Rolfe) Pérez-Vera",,2003,,"Orchidées Côte D'Ivoire 332 2003",,,,87c73068-8fcd-11eb-924d-9cd76263cbd0,,70027676-1,wfo-0000416225,5311836,,
-87f0570e-8fcd-11eb-924d-9cd76263cbd0,species,monoceras,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,db6472d2-8fcb-11eb-924d-9cd76263cbd0,,634782-1,wfo-0000960089,5312063,,
+87f0570e-8fcd-11eb-924d-9cd76263cbd0,species,monoceras,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db6472d2-8fcb-11eb-924d-9cd76263cbd0,,634782-1,wfo-0000960089,5312063,,
 87f072b6-8fcd-11eb-924d-9cd76263cbd0,species,monophylla,Eulophia,,"(A.Rich.) S.Moore",,1877,,"Fl. Mauritius 360 1877",,,,6eea24d4-8fcc-11eb-924d-9cd76263cbd0,,634783-1,wfo-0000960090,5323736,,
 87f08c42-8fcd-11eb-924d-9cd76263cbd0,species,monotropis,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 248 1916",,,,,,634784-1,wfo-0000960091,5311971,,
-87f0ab64-8fcd-11eb-924d-9cd76263cbd0,species,monteiroi,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,db649730-8fcb-11eb-924d-9cd76263cbd0,,634785-1,wfo-0000960092,5311630,,
+87f0ab64-8fcd-11eb-924d-9cd76263cbd0,species,monteiroi,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db649730-8fcb-11eb-924d-9cd76263cbd0,,634785-1,wfo-0000960092,5311630,,
 87f0c81a-8fcd-11eb-924d-9cd76263cbd0,species,monticola,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 582 1915",,,,,,634787-1,wfo-0000960093,8419353,,
 87f0e4bc-8fcd-11eb-924d-9cd76263cbd0,species,monticola,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 60 1897",,,,,,634786-1,wfo-0000960094,5311860,,
-87f0feac-8fcd-11eb-924d-9cd76263cbd0,species,montis-elgonis,Eulophia,,Summerh.,,1932,,"Bull. Misc. Inform. Kew 1932: 509 1932",,Q55782467,,,,634788-1,wfo-0000960095,5311825,,
+87f0feac-8fcd-11eb-924d-9cd76263cbd0,species,montis-elgonis,Eulophia,,Summerh.,,1932,,"Bull. Misc. Inform. Kew 1932: 509 1932","Bullock, A. A. (1932). New Species from Mount Elgon. Bulletin of Miscellaneous Information, 1932(10), 487. https://doi.org/10.2307/4113427
+
+
+",Q55782467,DOI:10.2307/4113427,,,634788-1,wfo-0000960095,5311825,,
 87f11b1c-8fcd-11eb-924d-9cd76263cbd0,species,moratii,Eulophia,,N.Hallé,,1977,,"in Fl. Nouv.-Caléd. 8: 246 1977",,,,,,634789-1,wfo-0000960096,5311777,,
 87f13548-8fcd-11eb-924d-9cd76263cbd0,species,mossambicensis,Eulophia,,Schelpe,,1976,,"J. S. African Bot. 42: 392 1976",,,,,,634790-1,wfo-0000960097,5311597,,
 87f15190-8fcd-11eb-924d-9cd76263cbd0,species,mucronata,Eulophia,,Blume,,1859,,"Coll. Orchid. 182 1859",,,,,,634791-1,wfo-0000960098,5312146,,
-87f16b58-8fcd-11eb-924d-9cd76263cbd0,species,multicolor,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,db654fae-8fcb-11eb-924d-9cd76263cbd0,,634792-1,wfo-0000960099,5311656,,
-87f186ce-8fcd-11eb-924d-9cd76263cbd0,species,mumbwaensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927",,Q55778720,,,,634793-1,wfo-0000960100,5311619,,
+87f16b58-8fcd-11eb-924d-9cd76263cbd0,species,multicolor,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db654fae-8fcb-11eb-924d-9cd76263cbd0,,634792-1,wfo-0000960099,5311656,,
+87f186ce-8fcd-11eb-924d-9cd76263cbd0,species,mumbwaensis,Eulophia,,Summerh.,,1927,,"Bull. Misc. Inform. Kew 1927: 416 1927","Summerhayes, V. S. (1927). African Orchids, I. Bulletin of Miscellaneous Information, 1927(10), 415. https://doi.org/10.2307/4107556
+
+
+",Q55778720,DOI:10.2307/4107556,,,634793-1,wfo-0000960100,5311619,,
 87f1a488-8fcd-11eb-924d-9cd76263cbd0,species,murrayana,Eulophia,,"(Gardner ex Hook.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960101,5325306,,
-87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,species,mweruensis,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 162 1977",,Q43230546,,,,634795-1,wfo-0000960102,5311533,,
+87f1c0bc-8fcd-11eb-924d-9cd76263cbd0,species,mweruensis,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 162 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,634795-1,wfo-0000960102,5311533,,
 87f1da70-8fcd-11eb-924d-9cd76263cbd0,species,nana,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 579 1915",,,,,,634796-1,wfo-0000960103,5311902,,
 87f22bec-8fcd-11eb-924d-9cd76263cbd0,species,natalensis,Eulophia,,Rchb.f.,,1865,,"Flora 48: 186 1865",,,,,,634797-1,wfo-0000960106,5311595,,
-87f2456e-8fcd-11eb-924d-9cd76263cbd0,species,nelsonii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910",,Q55782219,,,,634798-1,wfo-0000960107,5311399,,
+87f2456e-8fcd-11eb-924d-9cd76263cbd0,species,nelsonii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
+
+
+",Q55782219,DOI:10.2307/4113249,,,634798-1,wfo-0000960107,5311399,,
 87f261fc-8fcd-11eb-924d-9cd76263cbd0,species,neopommeranica,Eulophia,,J.J.Sm.,,1909,,"Nova Guinea 8: 26 1909",,,,,,634799-1,wfo-0000960108,5311843,,
-87f2809c-8fcd-11eb-924d-9cd76263cbd0,species,nervosa,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 150 1935",,Q55757322,,,,634800-1,wfo-0000960109,5312082,,
+87f2809c-8fcd-11eb-924d-9cd76263cbd0,species,nervosa,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 150 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634800-1,wfo-0000960109,5312082,,
 87f29c58-8fcd-11eb-924d-9cd76263cbd0,species,nicobarica,Eulophia,,"N.P.Balakr. & N.G.Nair",,1976,,"Bull. Bot. Surv. India 15: 271 1976",,,,,,634801-1,wfo-0000960110,5312055,,
 87f2b9e0-8fcd-11eb-924d-9cd76263cbd0,species,nigricans,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 5 1895",,,,,,634802-1,wfo-0000960111,5311295,,
 87f2d40c-8fcd-11eb-924d-9cd76263cbd0,species,norlindhii,Eulophia,,Summerh.,,1937,,"Bot. Not. 1937: 197 1937",,,,,,634803-1,wfo-0000960112,5312040,,
-87f2ee6a-8fcd-11eb-924d-9cd76263cbd0,species,novoebudae,Eulophia,,Kraenzl.,,1929,,"Bull. Soc. Bot. France 76: 301 1929",,Q55757220,,,,634804-1,wfo-0000960113,5311759,,
+87f2ee6a-8fcd-11eb-924d-9cd76263cbd0,species,novoebudae,Eulophia,,Kraenzl.,,1929,,"Bull. Soc. Bot. France 76: 301 1929","Guillaumin, A. (1929). Contribution à la flore des Nouvelles-Hébrides. Bulletin De La Société Botanique De France, 76(2), 298–303. https://doi.org/10.1080/00378941.1929.10837163
+
+
+",Q55757220,DOI:10.1080/00378941.1929.10837163,,,634804-1,wfo-0000960113,5311759,,
 87f308fa-8fcd-11eb-924d-9cd76263cbd0,species,nuda,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 180 1833",,,,,,,wfo-0000960114,5312136,,
 c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,wfo-0001088595,7809035,,
 87f32420-8fcd-11eb-924d-9cd76263cbd0,species,nutans,Eulophia,,Sond.,,1846,,"Linnaea 19: 73 1846",,,,,,634806-1,wfo-0000960115,5311390,,
 87f35b48-8fcd-11eb-924d-9cd76263cbd0,species,nuttii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 63 1897",,,,,,634807-1,wfo-0000960117,5311858,,
-87f375ce-8fcd-11eb-924d-9cd76263cbd0,species,nyasae,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894",,Q54554200,,,,634808-1,wfo-0000960118,5311816,,
-87f390d6-8fcd-11eb-924d-9cd76263cbd0,species,obcordata,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917",,Q55782426,,,,634809-1,wfo-0000960119,5311384,,
-87f3ac42-8fcd-11eb-924d-9cd76263cbd0,species,oblonga,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910",,Q55782219,,,,634810-1,wfo-0000960120,5311617,,
-87f3c808-8fcd-11eb-924d-9cd76263cbd0,species,obscura,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 171 1977",,Q43230546,,,,634811-1,wfo-0000960121,5311743,,
+87f375ce-8fcd-11eb-924d-9cd76263cbd0,species,nyasae,Eulophia,,Rendle,,1894,,"Trans. Linn. Soc. London, Bot. 4: 44 1894","I. The Plants of Milanji, Nyasa-land, collected by Mr. Alexander Whyte, F.L.S., and described by Messrs. Britten, E. G. Baker, Rendle, Gepp, and others; with an Introduction by William Carruthers, F.R.S., F.L.S. (1894). 4(1), 1-67. https://doi.org/10.1111/j.1095-8339.1894.tb00043.x
+
+
+",Q54554200,DOI:10.1111/j.1095-8339.1894.tb00043.x,,,634808-1,wfo-0000960118,5311816,,
+87f390d6-8fcd-11eb-924d-9cd76263cbd0,species,obcordata,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 82 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
+
+
+",Q55782426,DOI:10.2307/4113400,,,634809-1,wfo-0000960119,5311384,,
+87f3ac42-8fcd-11eb-924d-9cd76263cbd0,species,oblonga,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 370 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
+
+
+",Q55782219,DOI:10.2307/4113249,,,634810-1,wfo-0000960120,5311617,,
+87f3c808-8fcd-11eb-924d-9cd76263cbd0,species,obscura,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,634811-1,wfo-0000960121,5311743,,
 87f3e4f0-8fcd-11eb-924d-9cd76263cbd0,species,obstipa,Eulophia,,"P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 534 1998",,,,,,1005717-1,wfo-0000960122,5311688,,
 87f40340-8fcd-11eb-924d-9cd76263cbd0,species,obtusa,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 3 1890",,,,,,634812-1,wfo-0000960123,5311669,,
 87f42078-8fcd-11eb-924d-9cd76263cbd0,species,ochobiensis,Eulophia,,Hayata,,1916,,"Icon. Pl. Formosan. 6: 78 1916",,,,,,634813-1,wfo-0000960124,5311699,,
@@ -475,18 +805,33 @@ c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,
 87f49242-8fcd-11eb-924d-9cd76263cbd0,species,ochyrae,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 616 2001",,,,,,20000660-1,wfo-0000960128,5312124,,
 87f4ac78-8fcd-11eb-924d-9cd76263cbd0,species,odontoglossa,Eulophia,,Rchb.f.,,1846,,"Linnaea 19: 373 1846",,,,,,634816-1,wfo-0000960129,5311354,,
 87f4c910-8fcd-11eb-924d-9cd76263cbd0,species,oedoplectron,Eulophia,,Summerh.,,1936,,"Fl. W. Trop. Afr. 2: 444 1936",,,,,,634817-1,wfo-0000960130,5312023,,
-87f4e512-8fcd-11eb-924d-9cd76263cbd0,species,oliveriana,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889",,Q55760323,,,,634818-1,wfo-0000960131,5312173,,
-87f500ba-8fcd-11eb-924d-9cd76263cbd0,species,orthoplectra,Eulophia,,"(Rchb.f.) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 499 1939",,Q55782484,,,,634819-1,wfo-0000960132,5312117,,
+87f4e512-8fcd-11eb-924d-9cd76263cbd0,species,oliveriana,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634818-1,wfo-0000960131,5312173,,
+87f500ba-8fcd-11eb-924d-9cd76263cbd0,species,orthoplectra,Eulophia,,"(Rchb.f.) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 499 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454
+
+
+",Q55782484,DOI:10.2307/4113454,,,634819-1,wfo-0000960132,5312117,,
 87f51aa0-8fcd-11eb-924d-9cd76263cbd0,variety,rugulosa,Eulophia,orthoplectra,"(Summerh.) Geerinck",,1988,,"Fl. Rwanda 4: 575 1988",,,,880013ba-8fcd-11eb-924d-9cd76263cbd0,,954446-1,wfo-0000960133,5311425,,
 87f53634-8fcd-11eb-924d-9cd76263cbd0,variety,schweinfurthii,Eulophia,orthoplectra,"(Kraenzl.) Geerinck",,1988,,"Fl. Rwanda 4: 575 1988",,,,8802d2f8-8fcd-11eb-924d-9cd76263cbd0,,954447-1,wfo-0000960134,5311331,,
 87f5595c-8fcd-11eb-924d-9cd76263cbd0,species,ovalifolia,Eulophia,,"Ames & C.Schweinf.",,1920,,"Orchidaceae 6: 208 1920",,,,,,634820-1,wfo-0000960135,5305381,,
 87f57586-8fcd-11eb-924d-9cd76263cbd0,species,ovalis,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634821-1,wfo-0000960136,5311994,,
 87f5920a-8fcd-11eb-924d-9cd76263cbd0,subspecies,bainesii,Eulophia,ovalis,"(Rolfe) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 88 1965",,,,87c370d6-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960137,7896041,,
 87f5c82e-8fcd-11eb-924d-9cd76263cbd0,variety,bainesii,Eulophia,ovalis,"(Rolfe) P.J.Cribb & la Croix",,1998,,"in Fl. Zambes. 11(2): 473 1998",,,,87c370d6-8fcd-11eb-924d-9cd76263cbd0,,1005716-1,wfo-0000960139,5312002,,
-87f5fe84-8fcd-11eb-924d-9cd76263cbd0,species,ovatipetala,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910",,Q55781795,,,,634822-1,wfo-0000960141,5312001,,
-87f63b4c-8fcd-11eb-924d-9cd76263cbd0,species,paivaeana,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 151 1953",,Q55784833,,,,634823-1,wfo-0000960142,5311727,,
+87f5fe84-8fcd-11eb-924d-9cd76263cbd0,species,ovatipetala,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
+
+
+",Q55781795,DOI:10.2307/4111720,,,634822-1,wfo-0000960141,5312001,,
+87f63b4c-8fcd-11eb-924d-9cd76263cbd0,species,paivaeana,Eulophia,,"(Rchb.f.) Summerh.",,1953,,"Kew Bull. 8: 151 1953","Summerhayes, V. S. (1953). African Orchids: XXI. Kew Bulletin, 8(1), 129. https://doi.org/10.2307/4117167
+
+
+",Q55784833,DOI:10.2307/4117167,,,634823-1,wfo-0000960142,5311727,,
 87f6933a-8fcd-11eb-924d-9cd76263cbd0,subspecies,borealis,Eulophia,paivaeana,Summerh.,,1953,,"Kew Bull. 8: 152 1953",,,,,,,wfo-0000960143,5311719,,
-87f6bfea-8fcd-11eb-924d-9cd76263cbd0,species,palmicola,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 158 1935",,Q55757322,,,,634824-1,wfo-0000960144,5313540,,
+87f6bfea-8fcd-11eb-924d-9cd76263cbd0,species,palmicola,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 158 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634824-1,wfo-0000960144,5313540,,
 87f6e01a-8fcd-11eb-924d-9cd76263cbd0,species,pandurata,Eulophia,,Rolfe,,1891,,"J. Linn. Soc., Bot. 29: 52 1891",,,,,,,wfo-0000960145,5323743,,
 87f6ffbe-8fcd-11eb-924d-9cd76263cbd0,species,panganiana,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,634826-1,wfo-0000960146,5311358,,
 87f72016-8fcd-11eb-924d-9cd76263cbd0,species,paniculata,Eulophia,,Rolfe,,1905,,"Gard. Chron. 1905(2): 197 1905",,,,,,634827-1,wfo-0000960147,5323756,,
@@ -496,117 +841,219 @@ c3d60f66-8fcd-11eb-924d-9cd76263cbd0,species,nulnei,Eulophia,,Rchb.f.,,,,,,,,,,,
 87f7c16a-8fcd-11eb-924d-9cd76263cbd0,species,papuana,Eulophia,,"(Ridl.) J.J.Sm.",,1909,,"Nova Guinea 8: 26 1909",,,,,,634829-1,wfo-0000960152,8234945,,
 87f7e00a-8fcd-11eb-924d-9cd76263cbd0,species,paradoxa,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 68 1902",,,,,,634832-1,wfo-0000960153,5312061,,
 87f7fda6-8fcd-11eb-924d-9cd76263cbd0,variety,greatrexii,Eulophia,paradoxa,Merxm.,,1951,,"Contr. Fl. Marandellas 83 1951",,,,,,,wfo-0000960154,5312060,,
-87f81b92-8fcd-11eb-924d-9cd76263cbd0,species,parilamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634833-1,wfo-0000960155,5311307,,
+87f81b92-8fcd-11eb-924d-9cd76263cbd0,species,parilamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634833-1,wfo-0000960155,5311307,,
 87f83c8a-8fcd-11eb-924d-9cd76263cbd0,species,parviflora,Eulophia,,"(Lindl.) A.V.Hall",,1965,,"J. S. African Bot. Suppl. 5: 149 1965",,,,,,634834-1,wfo-0000960156,5312163,,
 87f85a80-8fcd-11eb-924d-9cd76263cbd0,species,parvilabris,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 201 1837",,,,,,634835-1,wfo-0000960157,5312110,,
-87f89586-8fcd-11eb-924d-9cd76263cbd0,species,parvula,Eulophia,,"(Rendle) Summerh.",,1957,,"Kew Bull. 12: 125 1957",,Q55779620,,,,634836-1,wfo-0000960158,5312043,,
-87f8f49a-8fcd-11eb-924d-9cd76263cbd0,species,pauciflora,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930",,Q55757232,,,,634837-1,wfo-0000960159,5312015,,
+87f89586-8fcd-11eb-924d-9cd76263cbd0,species,parvula,Eulophia,,"(Rendle) Summerh.",,1957,,"Kew Bull. 12: 125 1957","Summerhayes, V. S. (1957). African Orchids: XXIV. Kew Bulletin, 12(1), 107. https://doi.org/10.2307/4109113
+
+
+",Q55779620,DOI:10.2307/4109113,,,634836-1,wfo-0000960158,5312043,,
+87f8f49a-8fcd-11eb-924d-9cd76263cbd0,species,pauciflora,Eulophia,,Guillaumin,,1930,,"Bull. Soc. Bot. France 77: 338 1930","Guillaumin, A. (1930). Espèces et localités nouvelles d’Orchidées-Vandées d’Indo-Chine. Bulletin De La Société Botanique De France, 77(3), 326–340. https://doi.org/10.1080/00378941.1930.10833732
+
+
+",Q55757232,DOI:10.1080/00378941.1930.10833732,,,634837-1,wfo-0000960159,5312015,,
 87f9337e-8fcd-11eb-924d-9cd76263cbd0,species,paucisquamata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 125 1919",,,,,,634838-1,wfo-0000960161,5311770,,
 87f95192-8fcd-11eb-924d-9cd76263cbd0,species,pedicellata,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634839-1,wfo-0000960162,5311576,,
 87f96e70-8fcd-11eb-924d-9cd76263cbd0,species,peglerae,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 49 1912",,,,,,634840-1,wfo-0000960163,5311885,,
 54631760-8fcc-11eb-924d-9cd76263cbd0,species,pelorica,Eulophia,,"D.L.Jones & M.A.Clem.",,2004,,"Orchadian 14(8: Sci. Suppl.): ix 2004",,,,,,77062191-1,wfo-0000416234,5312108,,
 87f988d8-8fcd-11eb-924d-9cd76263cbd0,species,penduliflora,Eulophia,,Kraenzl.,,1901,,"Bot. Jahrb. Syst. 30: 288 1901",,,,,,634841-1,wfo-0000960164,5311899,,
-87f9a2fa-8fcd-11eb-924d-9cd76263cbd0,species,pentalamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634842-1,wfo-0000960165,5311956,,
+87f9a2fa-8fcd-11eb-924d-9cd76263cbd0,species,pentalamellata,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634842-1,wfo-0000960165,5311956,,
 87f9c000-8fcd-11eb-924d-9cd76263cbd0,species,pentheri,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 339 1899",,,,,,634843-1,wfo-0000960166,5311318,,
 87f9de64-8fcd-11eb-924d-9cd76263cbd0,species,perrieri,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 174 1913",,,,,,634844-1,wfo-0000960167,5311827,,
 87f9f886-8fcd-11eb-924d-9cd76263cbd0,species,petersii,Eulophia,,"(Rchb.f.) Rchb.f.",,1865,,"Flora 48: 186 1865",,,,8b8e3fca-8fcd-11eb-924d-9cd76263cbd0,,634845-1,wfo-0000960168,5311779,,
 87fa1320-8fcd-11eb-924d-9cd76263cbd0,species,petiolata,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 175 1913",,,,,,634846-1,wfo-0000960169,5323776,,
 87fa2de2-8fcd-11eb-924d-9cd76263cbd0,species,phillipsiae,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 56 1897",,,,,,634847-1,wfo-0000960170,5311780,,
 87fa65dc-8fcd-11eb-924d-9cd76263cbd0,species,pholelana,Eulophia,,"H.Kurze & O.Kurze",,1990,,"S. African Orchid J. 21: 78 1990",,,,,,958331-1,wfo-0000960172,5311620,,
-87fa831e-8fcd-11eb-924d-9cd76263cbd0,species,pileata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 468 1885",,Q55760268,,,,634848-1,wfo-0000960173,5311587,,
+87fa831e-8fcd-11eb-924d-9cd76263cbd0,species,pileata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 468 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
+
+
+",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634848-1,wfo-0000960173,5311587,,
 87faa0d8-8fcd-11eb-924d-9cd76263cbd0,species,pillansii,Eulophia,,Bolus,,1911,,"Icon. Orchid. Austro-Afric. 2: t. 27 1911",,,,,,634849-1,wfo-0000960174,5311434,,
 87fabd48-8fcd-11eb-924d-9cd76263cbd0,species,piscicelliana,Eulophia,,"Buscal. & Muschl.",,1913,,"Bot. Jahrb. Syst. 49: 463 1913",,,,,,634850-1,wfo-0000960175,5311432,,
 87fae390-8fcd-11eb-924d-9cd76263cbd0,species,plantaginea,Eulophia,,"(Thouars) Rolfe ex Hochr.",,1908,,"Annuaire Conserv. Jard. Bot. Genève 11-12: 56 1908",,,,3f0d5212-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960176,7925287,,
 87faff88-8fcd-11eb-924d-9cd76263cbd0,species,platypetala,Eulophia,,Lindl.,,1837,,"Companion Bot. Mag. 2: 202 1837",,,,,,634852-1,wfo-0000960177,5311437,,
-87fb1be4-8fcd-11eb-924d-9cd76263cbd0,species,plicata,Eulophia,,"(Harv. ex Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882",,Q55760231,,,,634853-1,wfo-0000960178,5311578,,
+87fb1be4-8fcd-11eb-924d-9cd76263cbd0,species,plicata,Eulophia,,"(Harv. ex Lindl.) Bolus",,1882,,"J. Linn. Soc., Bot. 19: 336 1882","Bolus, H. (1882). A List of published Species of Cape Orchideae. Transactions of the Linnean Society of London. Botany, 19(122), 335–347. https://doi.org/10.1111/j.1095-8339.1882.tb00378.x
+
+
+",Q55760231,DOI:10.1111/j.1095-8339.1882.tb00378.x,,,634853-1,wfo-0000960178,5311578,,
 87fb3598-8fcd-11eb-924d-9cd76263cbd0,species,poiformis,Eulophia,,Szlach.,,1993,,"Fragm. Florist. Geobot. 38: 463 1993",,,,,,976601-1,wfo-0000960179,5311447,,
 87fb5424-8fcd-11eb-924d-9cd76263cbd0,species,poilanei,Eulophia,,Gagnep.,,1931,,"Bull. Mus. Natl. Hist. Nat. II, 3: 683 1931",,,,,,634854-1,wfo-0000960180,5311305,,
-87fb756c-8fcd-11eb-924d-9cd76263cbd0,species,porphyroglossa,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889",,Q55760323,,e39e0652-8fcb-11eb-924d-9cd76263cbd0,,634855-1,wfo-0000960181,5311651,,
+87fb756c-8fcd-11eb-924d-9cd76263cbd0,species,porphyroglossa,Eulophia,,"(Rchb.f.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,e39e0652-8fcb-11eb-924d-9cd76263cbd0,,634855-1,wfo-0000960181,5311651,,
 87fbafc8-8fcd-11eb-924d-9cd76263cbd0,species,praestans,Eulophia,,Rendle,,1895,,"J. Bot. 33: 166 1895",,,,,,634856-1,wfo-0000960183,5311915,,
 87fbc97c-8fcd-11eb-924d-9cd76263cbd0,species,pratensis,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634857-1,wfo-0000960184,5312009,,
-87fbe3bc-8fcd-11eb-924d-9cd76263cbd0,species,praticola,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634858-1,wfo-0000960185,5312006,,
+87fbe3bc-8fcd-11eb-924d-9cd76263cbd0,species,praticola,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634858-1,wfo-0000960185,5312006,,
 87fbffa0-8fcd-11eb-924d-9cd76263cbd0,species,pretoriensis,Eulophia,,L.Bolus,,1933,,"Fl. Pl. South Africa 13: t. 500 1933",,,,,,634859-1,wfo-0000960186,5312004,,
 87fc1c38-8fcd-11eb-924d-9cd76263cbd0,species,preussii,Eulophia,,Kraenzl.,,1893,,"Bot. Jahrb. Syst. 17: 54 1893",,,,,,634860-1,wfo-0000960187,5311453,,
 87fc36c8-8fcd-11eb-924d-9cd76263cbd0,species,promensis,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,,wfo-0000960188,5311892,,
-87fc50ea-8fcd-11eb-924d-9cd76263cbd0,species,propinqua,Eulophia,,Hutch.,,1921,,"Bull. Misc. Inform. Kew 1921: 401 1921",,Q55782456,,,,634862-1,wfo-0000960189,5311367,,
+87fc50ea-8fcd-11eb-924d-9cd76263cbd0,species,propinqua,Eulophia,,Hutch.,,1921,,"Bull. Misc. Inform. Kew 1921: 401 1921","Hutchinson, J. (1921). A Contribution to the Flora of Northern Nigeria. Plants Collected on the Bauchi Plateau by Mr. H. V. Lely. Bulletin of Miscellaneous Information Kew, 1921(10), 353. https://doi.org/10.2307/4113423
+
+
+",Q55782456,DOI:10.2307/4113423,,,634862-1,wfo-0000960189,5311367,,
 87fc6d0a-8fcd-11eb-924d-9cd76263cbd0,species,protearum,Eulophia,,Rchb.f.,,1867,,"Flora 50: 104 1867",,,,,,634863-1,wfo-0000960190,5311824,,
 87fc86f0-8fcd-11eb-924d-9cd76263cbd0,species,pseudoramosa,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 175 1913",,,,,,634864-1,wfo-0000960191,5311312,,
 87fca342-8fcd-11eb-924d-9cd76263cbd0,species,pulchra,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634865-1,wfo-0000960192,5311750,,
 3715490c-8fcd-11eb-924d-9cd76263cbd0,variety,actinomorpha,Eulophia,pulchra,"W.M.Lin, Kuo Huang & T.P.Lin",,2006,,"Taiwania 51: 163 2006",,,,,,,wfo-0000808649,5312109,,
-87fcd93e-8fcd-11eb-924d-9cd76263cbd0,species,purpurascens,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910",,Q55781795,,,,634866-1,wfo-0000960194,5311406,,
-87fcf3a6-8fcd-11eb-924d-9cd76263cbd0,species,pusilla,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914",,Q55787805,,,,634867-1,wfo-0000960195,5311449,,
+87fcd93e-8fcd-11eb-924d-9cd76263cbd0,species,purpurascens,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 281 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
+
+
+",Q55781795,DOI:10.2307/4111720,,,634866-1,wfo-0000960194,5311406,,
+87fcf3a6-8fcd-11eb-924d-9cd76263cbd0,species,pusilla,Eulophia,,Rolfe,,1914,,"Bull. Misc. Inform. Kew 1914: 212 1914","New Orchids; Decade 42. (1914). Bulletin of Miscellaneous Information, 1914(6), 210. https://doi.org/10.2307/4119503
+
+
+",Q55787805,DOI:10.2307/4119503,,,634867-1,wfo-0000960195,5311449,,
 87fd1016-8fcd-11eb-924d-9cd76263cbd0,species,pyrophila,Eulophia,,"(Rchb.f.) Summerh.",,1947,,"Kew Bull. 2: 142 1947 publ. 1948",,,,,,,wfo-0000960196,5311604,,
 87fd2c4a-8fcd-11eb-924d-9cd76263cbd0,species,quadriloba,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 176 1913",,,,,,634869-1,wfo-0000960197,5323782,,
 87fd4842-8fcd-11eb-924d-9cd76263cbd0,species,quartiniana,Eulophia,,A.Rich.,,1850,,"Tent. Fl. Abyss. 2: 284 1850",,,,,,634871-1,wfo-0000960198,5311867,,
 87fd7dda-8fcd-11eb-924d-9cd76263cbd0,species,ramentacea,Eulophia,,Wight,,,,"Icon. Pl. Ind. Orient. 5: t. 1666 1851",,,,,,634873-1,wfo-0000960200,8108523,,
 87fd6188-8fcd-11eb-924d-9cd76263cbd0,species,ramentacea,Eulophia,,"(Roxb.) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,60448330-2,wfo-0000960199,5311483,,
-87fd9a54-8fcd-11eb-924d-9cd76263cbd0,species,ramifera,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958",,Q55785005,,,,634874-1,wfo-0000960201,5311375,,
+87fd9a54-8fcd-11eb-924d-9cd76263cbd0,species,ramifera,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 80 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634874-1,wfo-0000960201,5311375,,
 87fdd028-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Hayata,,1911,,"J. Coll. Sci. Imp. Univ. Tokyo 30(1): 332 1911",,,,,,634876-1,wfo-0000960203,8242956,,
-87fdb6a6-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885",,Q55760268,,,,634875-1,wfo-0000960202,5311309,,
+87fdb6a6-8fcd-11eb-924d-9cd76263cbd0,species,ramosa,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
+
+
+",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634875-1,wfo-0000960202,5311309,,
 87fe05fc-8fcd-11eb-924d-9cd76263cbd0,species,rara,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 582 1915",,,,,,634877-1,wfo-0000960205,5312081,,
-87fe21d6-8fcd-11eb-924d-9cd76263cbd0,species,recurvata,Eulophia,,G.Will.,,1980,,"Pl. Syst. Evol. 134: 70 1980",,Q55808601,,,,634878-1,wfo-0000960206,5311989,,
+87fe21d6-8fcd-11eb-924d-9cd76263cbd0,species,recurvata,Eulophia,,G.Will.,,1980,,"Pl. Syst. Evol. 134: 70 1980","Williamson, G. (1980). Contribution to the orchid flora of South Central Africa. Plant Systematics and Evolution, 134(1-2), 53–77. https://doi.org/10.1007/bf00985031
+
+
+",Q55808601,DOI:10.1007/bf00985031,,,634878-1,wfo-0000960206,5311989,,
 87fe3aea-8fcd-11eb-924d-9cd76263cbd0,species,regnieri,Eulophia,,"(Rchb.f.) Guillaumin",,1955,,"Bull. Mus. Natl. Hist. Nat. II, 27: 395 1955",,,,,,634879-1,wfo-0000960207,5312137,,
 87fe5476-8fcd-11eb-924d-9cd76263cbd0,species,rehmannii,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 41 1912",,,,,,634880-1,wfo-0000960208,5312112,,
-87fe721c-8fcd-11eb-924d-9cd76263cbd0,species,reichenbachiana,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 185 1889",,Q55760323,,,,634881-1,wfo-0000960209,5312076,,
+87fe721c-8fcd-11eb-924d-9cd76263cbd0,species,reichenbachiana,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 185 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634881-1,wfo-0000960209,5312076,,
 87fe9030-8fcd-11eb-924d-9cd76263cbd0,species,renschiana,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1894,,"Consp. Fl. Afric. 5: 25 1894",,,,,,634882-1,wfo-0000960210,5311920,,
 c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.Durand & Schinz",,1895,,"Consp. Fl. Afr. 5: 25 1895",,,,,,,wfo-0001088705,,,
-87feac82-8fcd-11eb-924d-9cd76263cbd0,species,reticulata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885",,Q55760268,,,,634883-1,wfo-0000960211,5311888,,
+87feac82-8fcd-11eb-924d-9cd76263cbd0,species,reticulata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 470 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
+
+
+",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634883-1,wfo-0000960211,5311888,,
 87fec938-8fcd-11eb-924d-9cd76263cbd0,species,rhodesiaca,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 248 1916",,,,,,634884-1,wfo-0000960212,5311871,,
-87fee558-8fcd-11eb-924d-9cd76263cbd0,species,richardsiae,Eulophia,,"P.J.Cribb & la Croix",,,,"Kew Bull. 52: 1001 1997",,Q55785303,,,,998696-1,wfo-0000960213,5311838,,
+87fee558-8fcd-11eb-924d-9cd76263cbd0,species,richardsiae,Eulophia,,"P.J.Cribb & la Croix",,,,"Kew Bull. 52: 1001 1997","Cribb, P. J., & Croix, I. L. (1997). Two New Orchids from the Flora Zambesiaca Area. Kew Bulletin, 52(4), 1001. https://doi.org/10.2307/4117828
+
+
+",Q55785303,DOI:10.2307/4117828,,,998696-1,wfo-0000960213,5311838,,
 87ff01fa-8fcd-11eb-924d-9cd76263cbd0,species,rigidifolia,Eulophia,,Kraenzl.,,1914,,"Bot. Jahrb. Syst. 51: 387 1914",,,,,,634885-1,wfo-0000960214,5311338,,
 87ff53f8-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Schltr.,,1913,,"Ann. Mus. Colon. Marseille III, 1: 172 1913",,,,,,634887-1,wfo-0000960217,7827453,,
-87ff3756-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910",,Q55782219,,,,634886-1,wfo-0000960216,5311935,,
+87ff3756-8fcd-11eb-924d-9cd76263cbd0,species,robusta,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
+
+
+",Q55782219,DOI:10.2307/4113249,,,634886-1,wfo-0000960216,5311935,,
 87ff6fd2-8fcd-11eb-924d-9cd76263cbd0,species,rolfeana,Eulophia,,Kraenzl.,,1903,,"Kunene-Sambesi Exped. 213 1903",,,,,,634888-1,wfo-0000960218,5311685,,
 87ff8936-8fcd-11eb-924d-9cd76263cbd0,species,rosea,Eulophia,,A.D.Hawkes,,1964,,"Orchid Rev. 72: 27 1964",,,,,,634889-1,wfo-0000960219,5311640,,
-87ffa47a-8fcd-11eb-924d-9cd76263cbd0,species,roseolabia,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634890-1,wfo-0000960220,5311977,,
+87ffa47a-8fcd-11eb-924d-9cd76263cbd0,species,roseolabia,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634890-1,wfo-0000960220,5311977,,
 87ffbeec-8fcd-11eb-924d-9cd76263cbd0,species,rostrata,Eulophia,,"(Hook.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,cf3f42fa-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960221,5312562,,
 87ffdae4-8fcd-11eb-924d-9cd76263cbd0,species,rouxii,Eulophia,,Kraenzl.,,1914,,"Nova Caledonia, Bot. 1: 82 1914",,,,,,634892-1,wfo-0000960222,5311752,,
 87fff524-8fcd-11eb-924d-9cd76263cbd0,species,rueppelii,Eulophia,,"(Rchb.f.) Summerh.",,1940,,"Gard. Chron. III, 107: 220 1940",,,,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,634893-1,wfo-0000960223,5311713,,
-880013ba-8fcd-11eb-924d-9cd76263cbd0,species,rugulosa,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 77 1958",,Q55785005,,,,634894-1,wfo-0000960224,5311423,,
+880013ba-8fcd-11eb-924d-9cd76263cbd0,species,rugulosa,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 77 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634894-1,wfo-0000960224,5311423,,
 88002fb2-8fcd-11eb-924d-9cd76263cbd0,species,rupestris,Eulophia,,"Wall. ex Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 185 1833",,,,,,,wfo-0000960225,7721170,,
 880068c4-8fcd-11eb-924d-9cd76263cbd0,species,rupestris,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 682 1847",,,,,,634895-1,wfo-0000960227,5311481,,
 88008322-8fcd-11eb-924d-9cd76263cbd0,species,rupincola,Eulophia,,Rchb.f.,,1857,,"Bonplandia (Hannover) 5: 38 1857",,,,,,634897-1,wfo-0000960228,5312166,,
 8800a0aa-8fcd-11eb-924d-9cd76263cbd0,species,rutenbergiana,Eulophia,,Kraenzl.,,1882,,"Abh. Naturwiss. Vereins Bremen 7: 255 1882",,,,,,634898-1,wfo-0000960229,5312067,,
 8800be3c-8fcd-11eb-924d-9cd76263cbd0,species,ruwenzoriensis,Eulophia,,Rendle,,1895,,"J. Bot. 33: 166 1895",,,,,,634899-1,wfo-0000960230,5312017,,
 8800dc96-8fcd-11eb-924d-9cd76263cbd0,species,sabulosa,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 578 1915",,,,,,634900-1,wfo-0000960231,5311992,,
-8800f762-8fcd-11eb-924d-9cd76263cbd0,species,saintenoyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990",,Q55776633,,,,940396-1,wfo-0000960232,5311422,,
+8800f762-8fcd-11eb-924d-9cd76263cbd0,species,saintenoyana,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 186 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940396-1,wfo-0000960232,5311422,,
 88011382-8fcd-11eb-924d-9cd76263cbd0,species,sandersonii,Eulophia,,"(Rchb.f.) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,db6bd4be-8fcb-11eb-924d-9cd76263cbd0,,634901-1,wfo-0000960233,5311644,,
 88012fca-8fcd-11eb-924d-9cd76263cbd0,species,sanguinea,Eulophia,,"(Lindl.) Hook.f.",,1890,,"Fl. Brit. India 6: 8 1890",,,,,,634902-1,wfo-0000960234,5311698,,
 88014d8e-8fcd-11eb-924d-9cd76263cbd0,species,sankeyi,Eulophia,,Rolfe,,1912,,"Fl. Cap. 5(3): 46 1912",,,,,,634903-1,wfo-0000960235,5311965,,
 88016a4e-8fcd-11eb-924d-9cd76263cbd0,species,sankisiensis,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 126 1919",,,,,,634904-1,wfo-0000960236,5311872,,
 88019e38-8fcd-11eb-924d-9cd76263cbd0,species,sapinii,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 103 1919",,,,,,634905-1,wfo-0000960238,5311513,,
 8801bcb0-8fcd-11eb-924d-9cd76263cbd0,species,sarticulata,Eulophia,,Lindl.,,1833,,"Gen. Sp. Orchid. Pl. 181 1833",,,,,,634906-1,wfo-0000960239,5311674,,
-8801d8a8-8fcd-11eb-924d-9cd76263cbd0,species,saundersiae,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910",,Q55782215,,,,634907-1,wfo-0000960240,5312175,,
+8801d8a8-8fcd-11eb-924d-9cd76263cbd0,species,saundersiae,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 368 1910","Gamble, J. S. (1910). New Lauraceae from the Malayan Region. IV. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1910(10), 357. https://doi.org/10.2307/4113248
+
+
+",Q55782215,DOI:10.2307/4113248,,,634907-1,wfo-0000960240,5312175,,
 8801f252-8fcd-11eb-924d-9cd76263cbd0,species,saundersiana,Eulophia,,Rchb.f.,,1866,,"Bot. Zeitung (Berlin) 24: 378 1866",,,,,,634908-1,wfo-0000960241,5323767,,
-88020dbe-8fcd-11eb-924d-9cd76263cbd0,species,saxicola,Eulophia,,"P.J.Cribb & G.Will.",,1977,,"Kew Bull. 32: 171 1977",,Q43230546,,,,634909-1,wfo-0000960242,5311623,,
-88022768-8fcd-11eb-924d-9cd76263cbd0,species,sceptrum,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634910-1,wfo-0000960243,5311657,,
-88024112-8fcd-11eb-924d-9cd76263cbd0,species,schaijesii,Eulophia,,Geerinck,,1985,,"Bull. Jard. Bot. Natl. Belg. 55: 501 1985",,Q55776480,,,,906058-1,wfo-0000960244,5311559,,
+88020dbe-8fcd-11eb-924d-9cd76263cbd0,species,saxicola,Eulophia,,"P.J.Cribb & G.Will.",,1977,,"Kew Bull. 32: 171 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,634909-1,wfo-0000960242,5311623,,
+88022768-8fcd-11eb-924d-9cd76263cbd0,species,sceptrum,Eulophia,,"(Schltr.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634910-1,wfo-0000960243,5311657,,
+88024112-8fcd-11eb-924d-9cd76263cbd0,species,schaijesii,Eulophia,,Geerinck,,1985,,"Bull. Jard. Bot. Natl. Belg. 55: 501 1985","Geerinck, D. (1985). Orchidaceae nouvelles du Zaire. Bulletin Van De Nationale Plantentuin Van België, 55(3/4), 501. https://doi.org/10.2307/3667975
+
+
+",Q55776480,DOI:10.2307/3667975,,,906058-1,wfo-0000960244,5311559,,
 88025aee-8fcd-11eb-924d-9cd76263cbd0,species,schimperiana,Eulophia,,A.Rich.,,1850,,"Tent. Fl. Abyss. 2: 283 1850",,,,,,634911-1,wfo-0000960245,5311786,,
-88027c22-8fcd-11eb-924d-9cd76263cbd0,species,schlechteri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935",,Q55757322,,,,634912-1,wfo-0000960246,5323779,,
+88027c22-8fcd-11eb-924d-9cd76263cbd0,species,schlechteri,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 154 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634912-1,wfo-0000960246,5323779,,
 88029c20-8fcd-11eb-924d-9cd76263cbd0,species,schnelliae,Eulophia,,L.Bolus,,1946,,"Fl. Pl. Africa 25: t. 965 1946",,,,,,634913-1,wfo-0000960247,5311926,,
 8802d2f8-8fcd-11eb-924d-9cd76263cbd0,species,schweinfurthii,Eulophia,,Kraenzl.,,1893,,"Bot. Jahrb. Syst. 17: 54 1893",,,,,,634914-1,wfo-0000960249,5311317,,
 8802ef86-8fcd-11eb-924d-9cd76263cbd0,species,sclerophylla,Eulophia,,Rchb.f.,,1885,,"Flora 68: 542 1885",,,,,,634915-1,wfo-0000960250,5323750,,
-88030dfe-8fcd-11eb-924d-9cd76263cbd0,species,scottii,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634916-1,wfo-0000960251,5311661,,
+88030dfe-8fcd-11eb-924d-9cd76263cbd0,species,scottii,Eulophia,,Butzin,,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634916-1,wfo-0000960251,5311661,,
 88032bfe-8fcd-11eb-924d-9cd76263cbd0,species,scripta,Eulophia,,"(Thouars) Lindl.",,1833,,"Gen. Sp. Orchid. Pl. 182 1833",,,,,,634917-1,wfo-0000960252,5308342,,
 88034c74-8fcd-11eb-924d-9cd76263cbd0,variety,concolor,Eulophia,scripta,"(Thouars) S.Moore",,1877,,"Fl. Mauritius 360 1877",,,,da681d20-8fcb-11eb-924d-9cd76263cbd0,,,wfo-0000960253,5308346,,
-8803693e-8fcd-11eb-924d-9cd76263cbd0,species,segawae,Eulophia,,Fukuy.,,1934,,"Bot. Mag. (Tokyo) 48: 437 1934",,Q55762706,,,,634918-1,wfo-0000960254,5311905,,
-88038446-8fcd-11eb-924d-9cd76263cbd0,species,seleensis,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 589 1975",,Q105743545,,,,634919-1,wfo-0000960255,5311982,,
+8803693e-8fcd-11eb-924d-9cd76263cbd0,species,segawae,Eulophia,,Fukuy.,,1934,,"Bot. Mag. (Tokyo) 48: 437 1934","Fukuyama, N. (1934). Studia Orchidacearum Japonicarum III(Continued from Ann. Rep. Taihoku Bot. Gard. Vol. III.). Botanical Magazine, 48(571), 429–442. https://doi.org/10.15281/jplantres1887.48.429
+
+
+",Q55762706,DOI:10.15281/jplantres1887.48.429,,,634918-1,wfo-0000960254,5311905,,
+88038446-8fcd-11eb-924d-9cd76263cbd0,species,seleensis,Eulophia,,"(De Wild.) Butzin",,1975,,"Willdenowia 7: 589 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634919-1,wfo-0000960255,5311982,,
 8803a1ec-8fcd-11eb-924d-9cd76263cbd0,variety,kisanfuensis,Eulophia,seleensis,"(De Wild.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 686 1992",,,,,,967487-1,wfo-0000960256,5311988,,
 8803bc72-8fcd-11eb-924d-9cd76263cbd0,variety,tenuiscapa,Eulophia,seleensis,"(Schltr.) Geerinck",,1992,,"in Fl. Afr. Centr. Sperm., Orch.(2): 685 1992",,,,880a7026-8fcd-11eb-924d-9cd76263cbd0,,967486-1,wfo-0000960257,5311985,,
 8803d90a-8fcd-11eb-924d-9cd76263cbd0,species,serrata,Eulophia,,P.J.Cribb,,1989,,"in Fl. Trop. E. Afr. Orchid.(3): 442 1989",,,,,,941226-1,wfo-0000960258,5311492,,
-880410e6-8fcd-11eb-924d-9cd76263cbd0,species,seychellarum,Eulophia,,"Rolfe ex Summerh.",,1928,,"Bull. Misc. Inform. Kew 1928: 393 1928",,Q55778525,,,,634920-1,wfo-0000960260,5323734,,
+880410e6-8fcd-11eb-924d-9cd76263cbd0,species,seychellarum,Eulophia,,"Rolfe ex Summerh.",,1928,,"Bull. Misc. Inform. Kew 1928: 393 1928","Summerhayes, V. S. (1928). New Plants from the Seychelles. Bulletin of Miscellaneous Information - Royal Botanic Gardens, Kew, 1928(10), 388. https://doi.org/10.2307/4107106
+
+
+",Q55778525,DOI:10.2307/4107106,,,634920-1,wfo-0000960260,5323734,,
 88042b26-8fcd-11eb-924d-9cd76263cbd0,species,shupangae,Eulophia,,"(Rchb.f.) Kraenzl.",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,7d30d7ee-8fcd-11eb-924d-9cd76263cbd0,,,wfo-0000960261,5311372,,
-880447c8-8fcd-11eb-924d-9cd76263cbd0,species,siamensis,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925",,Q55778673,,,,634922-1,wfo-0000960262,5311760,,
+880447c8-8fcd-11eb-924d-9cd76263cbd0,species,siamensis,Eulophia,,"Rolfe ex Downie",,1925,,"Bull. Misc. Inform. Kew 1925: 380 1925","Downie, D. G. (1925). Contributions to the Flora of Siam. Additamentum XVI. Bulletin of Miscellaneous Information, 1925(9), 367. https://doi.org/10.2307/4107477
+
+
+",Q55778673,DOI:10.2307/4107477,,,634922-1,wfo-0000960262,5311760,,
 88046492-8fcd-11eb-924d-9cd76263cbd0,species,silvatica,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 586 1915",,,,,,634923-1,wfo-0000960263,5311755,,
 88047f18-8fcd-11eb-924d-9cd76263cbd0,species,sinensis,Eulophia,,Miq.,,1861,,"J. Bot. Néerl. 1: 91 1861",,,,,,634924-1,wfo-0000960264,5312162,,
 8804991c-8fcd-11eb-924d-9cd76263cbd0,species,smithii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 54 1897",,,,,,634925-1,wfo-0000960265,5311782,,
 8804b5d2-8fcd-11eb-924d-9cd76263cbd0,species,sooi,Eulophia,,"Chun & Tang ex S.C.Chen",,1999,,"in Fl. Reipubl. Popul. Sin. 18: 412 1999",,,,,,1019125-1,wfo-0000960266,5311618,,
 8804d22e-8fcd-11eb-924d-9cd76263cbd0,species,sordida,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 67 1902",,,,,,634926-1,wfo-0000960267,5311585,,
-8804ee26-8fcd-11eb-924d-9cd76263cbd0,species,spathulifera,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 157 1935",,Q55757322,,,,634927-1,wfo-0000960268,5323752,,
+8804ee26-8fcd-11eb-924d-9cd76263cbd0,species,spathulifera,Eulophia,,H.Perrier,,1935,,"Bull. Soc. Bot. France 82: 157 1935","Perrier, H., & Bathie, L. (1935). LesEulophiade Madagascar. Bulletin De La Société Botanique De France, 82(2), 146–161. https://doi.org/10.1080/00378941.1935.10832966
+
+
+",Q55757322,DOI:10.1080/00378941.1935.10832966,,,634927-1,wfo-0000960268,5323752,,
 88054416-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 63 1897",,,,,,634929-1,wfo-0000960271,8213600,,
-880509a6-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,"(R.Br.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889",,Q55760323,,,,634928-1,wfo-0000960269,5311380,,
+880509a6-8fcd-11eb-924d-9cd76263cbd0,species,speciosa,Eulophia,,"(R.Br.) Bolus",,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634928-1,wfo-0000960269,5311380,,
 364715fa-8fcd-11eb-924d-9cd76263cbd0,variety,culveri,Eulophia,speciosa,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 10 1895",,,,,,,wfo-0000807056,5311499,,
-88056144-8fcd-11eb-924d-9cd76263cbd0,species,speciosissima,Eulophia,,Butzin,,1975,,"Willdenowia 7: 590 1975",,Q105743545,,,,634930-1,wfo-0000960272,5311378,,
+88056144-8fcd-11eb-924d-9cd76263cbd0,species,speciosissima,Eulophia,,Butzin,,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634930-1,wfo-0000960272,5311378,,
 88059b3c-8fcd-11eb-924d-9cd76263cbd0,species,spectabilis,Eulophia,,"(Dennst.) Suresh",,1988,,"Interpret. Van Rheede's Hort. Malab. 300 1988",,,,cbb0ea5e-8fcc-11eb-924d-9cd76263cbd0,,945130-1,wfo-0000960273,5312126,,
 8805fcee-8fcd-11eb-924d-9cd76263cbd0,species,sphaerocarpa,Eulophia,,Sond.,,1846,,"Linnaea 19: 74 1846",,,,,,634931-1,wfo-0000960274,5312513,,
 880644ba-8fcd-11eb-924d-9cd76263cbd0,species,squalida,Eulophia,,Lindl.,,1841,,"Edwards's Bot. Reg. 27(Misc.): 77 1841",,,,,,634932-1,wfo-0000960275,5312131,,
@@ -614,26 +1061,47 @@ c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.
 88067f70-8fcd-11eb-924d-9cd76263cbd0,species,stenantha,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 27 1895",,,,,,634934-1,wfo-0000960277,5311558,,
 88069c4e-8fcd-11eb-924d-9cd76263cbd0,species,stenochila,Eulophia,,"(Lodd.) Steud.",,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960278,5310368,,
 8806b95e-8fcd-11eb-924d-9cd76263cbd0,species,stenopetala,Eulophia,,Lindl.,,1858,,"J. Proc. Linn. Soc., Bot. 3: 26 1858",,,,,,634936-1,wfo-0000960279,5311969,,
-8806d61e-8fcd-11eb-924d-9cd76263cbd0,species,stenophylla,Eulophia,,Summerh.,,1949,,"Kew Bull. 4: 434 1949",,Q55779639,,,,634937-1,wfo-0000960280,5311710,,
-88070f9e-8fcd-11eb-924d-9cd76263cbd0,species,stenoplectra,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 81 1958",,Q55785005,,,,634938-1,wfo-0000960282,5311857,,
+8806d61e-8fcd-11eb-924d-9cd76263cbd0,species,stenophylla,Eulophia,,Summerh.,,1949,,"Kew Bull. 4: 434 1949","Summerhayes, V. S. (1949). African Orchids: XIX. Kew Bulletin, 4(3), 427. https://doi.org/10.2307/4109203
+
+
+",Q55779639,DOI:10.2307/4109203,,,634937-1,wfo-0000960280,5311710,,
+88070f9e-8fcd-11eb-924d-9cd76263cbd0,species,stenoplectra,Eulophia,,Summerh.,,1958,,"Kew Bull. 13: 81 1958","Summerhayes, V. S. (1958). African Orchids: XXV. Kew Bulletin, 13(1), 57. https://doi.org/10.2307/4117623
+
+
+",Q55785005,DOI:10.2307/4117623,,,634938-1,wfo-0000960282,5311857,,
 88072c22-8fcd-11eb-924d-9cd76263cbd0,species,stewartiae,Eulophia,,Rolfe,,1916,,"Bull. Misc. Inform. Kew 1916: 78 1916",,,,,,,wfo-0000960283,5312114,,
 8807477a-8fcd-11eb-924d-9cd76263cbd0,species,stolziana,Eulophia,,"(Kraenzl.) Engl.",,1908,,"Veg. Erde 9(II): 444 1908",,,,7d311222-8fcd-11eb-924d-9cd76263cbd0,,634940-1,wfo-0000960284,5312100,,
 880761d8-8fcd-11eb-924d-9cd76263cbd0,species,stolzii,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 577 1915",,,,,,634941-1,wfo-0000960285,5311543,,
 88077ec0-8fcd-11eb-924d-9cd76263cbd0,species,streptopetala,Eulophia,,Lindl.,,,,"Bot. Reg. 12: t. 1002 1826",,,,,,634942-1,wfo-0000960286,5311707,,
-88079982-8fcd-11eb-924d-9cd76263cbd0,variety,rueppelii,Eulophia,streptopetala,"(Rchb.f.) P.J.Cribb",,1979,,"Kew Bull. 33: 676 1979",,Q55779796,,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,887512-1,wfo-0000960287,,,
+88079982-8fcd-11eb-924d-9cd76263cbd0,variety,rueppelii,Eulophia,streptopetala,"(Rchb.f.) P.J.Cribb",,1979,,"Kew Bull. 33: 676 1979","Cribb, P. J. (1979). The Orchids of Arabia. Kew Bulletin, 33(4), 651. https://doi.org/10.2307/4109808
+
+
+",Q55779796,DOI:10.2307/4109808,db6b36a8-8fcb-11eb-924d-9cd76263cbd0,,887512-1,wfo-0000960287,,,
 8807b412-8fcd-11eb-924d-9cd76263cbd0,variety,stenophylla,Eulophia,streptopetala,"(Summerh.) P.J.Cribb",,1989,,"in Fl. Trop. E. Afr. Orchid.(3): 471 1989",,,,,,955895-1,wfo-0000960288,5311708,,
 8807ebb2-8fcd-11eb-924d-9cd76263cbd0,species,striata,Eulophia,,Rolfe,,1891,,"J. Linn. Soc., Bot. 29: 53 1891",,,,,,,wfo-0000960290,5311751,,
 88080750-8fcd-11eb-924d-9cd76263cbd0,species,stricta,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 51 1897",,,,,,634945-1,wfo-0000960291,5311491,,
 88084116-8fcd-11eb-924d-9cd76263cbd0,species,stricta,Eulophia,,"(C.Presl) Ames",,1915,,"Orchidaceae 5: 103 1915",,,,,,634946-1,wfo-0000960293,7390713,,
-88085e76-8fcd-11eb-924d-9cd76263cbd0,species,stuhlmannii,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 590 1975",,Q105743545,,,,634947-1,wfo-0000960294,5311725,,
+88085e76-8fcd-11eb-924d-9cd76263cbd0,species,stuhlmannii,Eulophia,,"(Kraenzl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634947-1,wfo-0000960294,5311725,,
 880879a6-8fcd-11eb-924d-9cd76263cbd0,species,stylites,Eulophia,,"(Rchb.f.) A.D.Hawkes",,1964,,"Orchid Rev. 72: 27 1964",,,,db6dffdc-8fcb-11eb-924d-9cd76263cbd0,,634948-1,wfo-0000960295,5311633,,
 88089418-8fcd-11eb-924d-9cd76263cbd0,species,subintegra,Eulophia,,Rolfe,,1912,,"Fl. Cap. 6(3): 41 1912",,,,,,,wfo-0000960296,5312012,,
 8808b0ec-8fcd-11eb-924d-9cd76263cbd0,species,subsaprophytica,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 576 1915",,,,,,634950-1,wfo-0000960297,5312116,,
 8808d040-8fcd-11eb-924d-9cd76263cbd0,species,subulata,Eulophia,,Rendle,,1895,,"J. Bot. 33: 167 1895",,,,,,634951-1,wfo-0000960298,5312078,,
 8808ece2-8fcd-11eb-924d-9cd76263cbd0,species,sumatrana,Eulophia,,Blume,,1859,,"Coll. Orchid. 183 1859",,,,,,634952-1,wfo-0000960299,5312147,,
-88090844-8fcd-11eb-924d-9cd76263cbd0,species,suzannae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990",,Q55776633,,,,940397-1,wfo-0000960300,5311993,,
-880921bc-8fcd-11eb-924d-9cd76263cbd0,species,swynnertonii,Eulophia,,Rendle,,1911,,"J. Linn. Soc., Bot. 40: 207 1911",,Q55760482,,,,634953-1,wfo-0000960301,5312164,,
-88093ddc-8fcd-11eb-924d-9cd76263cbd0,species,sylviae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990",,Q55776633,,,,940398-1,wfo-0000960302,5311962,,
+88090844-8fcd-11eb-924d-9cd76263cbd0,species,suzannae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940397-1,wfo-0000960300,5311993,,
+880921bc-8fcd-11eb-924d-9cd76263cbd0,species,swynnertonii,Eulophia,,Rendle,,1911,,"J. Linn. Soc., Bot. 40: 207 1911","Rendle, A. B., Baker, E. G., Moore, S., & Gepp, A. (1911). A Contribution to our Knowledge of the Flora of Gazaland: being an Account of Collections made by C. F. M. Swynnerton Esq., F.L.S. Transactions of the Linnean Society of London: Botany, 40(275), 1–245. https://doi.org/10.1111/j.1095-8339.1911.tb00869.x
+
+
+",Q55760482,DOI:10.1111/j.1095-8339.1911.tb00869.x,,,634953-1,wfo-0000960301,5312164,,
+88093ddc-8fcd-11eb-924d-9cd76263cbd0,species,sylviae,Eulophia,,Geerinck,,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 187 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940398-1,wfo-0000960302,5311962,,
 88097612-8fcd-11eb-924d-9cd76263cbd0,species,tabularis,Eulophia,,"(L.f.) Bolus",,1888,,"Trans. S. African Philos. Soc. 5(1): 108 1888",,,,,,634954-1,wfo-0000960304,5311882,,
 88099160-8fcd-11eb-924d-9cd76263cbd0,species,tainioides,Eulophia,,Schltr.,,1899,,"Bot. Jahrb. Syst. 26: 339 1899",,,,,,634955-1,wfo-0000960305,5323730,,
 8809aed4-8fcd-11eb-924d-9cd76263cbd0,species,taitensis,Eulophia,,"Pfennig & P.J.Cribb",,1977,,"Orchidee (Hamburg) 28: 215 1977",,,,,,634956-1,wfo-0000960306,5311837,,
@@ -642,33 +1110,66 @@ c3e26e78-8fcd-11eb-924d-9cd76263cbd0,species,renschianus,Eulophia,,"(Rchb.f.) T.
 8809e7aa-8fcd-11eb-924d-9cd76263cbd0,species,tanganyikae,Eulophia,,Kraenzl.,,1900,,"Bull. Soc. Roy. Bot. Belgique 38: 216 1900",,,,,,,wfo-0000960308,5312045,,
 880a02e4-8fcd-11eb-924d-9cd76263cbd0,species,tanganyikensis,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 59 1897",,,,,,634959-1,wfo-0000960309,5311746,,
 880a1f86-8fcd-11eb-924d-9cd76263cbd0,species,tayloriana,Eulophia,,"(Rendle) Rolfe",,1897,,"Fl. Trop. Afr. 7: 69 1897",,,,,,634960-1,wfo-0000960310,5307902,,
-880a39e4-8fcd-11eb-924d-9cd76263cbd0,species,taylorii,Eulophia,,"(Ridl.) Butzin",,1975,,"Willdenowia 7: 590 1975",,Q105743545,,db6e3ea2-8fcb-11eb-924d-9cd76263cbd0,,634961-1,wfo-0000960311,5311606,,
+880a39e4-8fcd-11eb-924d-9cd76263cbd0,species,taylorii,Eulophia,,"(Ridl.) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,db6e3ea2-8fcb-11eb-924d-9cd76263cbd0,,634961-1,wfo-0000960311,5311606,,
 880a5384-8fcd-11eb-924d-9cd76263cbd0,species,tenella,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 681 1847",,,,,,634962-1,wfo-0000960312,5311592,,
 880a7026-8fcd-11eb-924d-9cd76263cbd0,species,tenuiscapa,Eulophia,,Schltr.,,1916,,"Wiss. Erg. Schwed. Rhod.-Kongo Exped. 1: 219 1916",,,,,,634963-1,wfo-0000960313,5311987,,
 880aa640-8fcd-11eb-924d-9cd76263cbd0,species,thollonii,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 652 2001",,,,,,20000662-1,wfo-0000960315,5311442,,
 880ac09e-8fcd-11eb-924d-9cd76263cbd0,species,thomsonii,Eulophia,,Rolfe,,1897,,"Fl. Trop. Afr. 7: 66 1897",,,,,,634964-1,wfo-0000960316,5311457,,
-880adb88-8fcd-11eb-924d-9cd76263cbd0,species,thunbergii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910",,Q55782219,,,,634965-1,wfo-0000960317,5311996,,
+880adb88-8fcd-11eb-924d-9cd76263cbd0,species,thunbergii,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 369 1910","New Orchids: Decade 37. (1910). Bulletin of Miscellaneous Information Kew, 1910(10), 368. https://doi.org/10.2307/4113249
+
+
+",Q55782219,DOI:10.2307/4113249,,,634965-1,wfo-0000960317,5311996,,
 880af85c-8fcd-11eb-924d-9cd76263cbd0,species,tisserantii,Eulophia,,"Szlach. & Olszewski",,2001,,"in Fl. Cameroun 35: 654 2001",,,,,,20000663-1,wfo-0000960318,5312039,,
 880b35ba-8fcd-11eb-924d-9cd76263cbd0,species,toyoshimae,Eulophia,,Nakai,,1920,,"Bot. Mag. (Tokyo) 34: 145 1920",,,,,,634966-1,wfo-0000960319,5311306,,
-880b5ca2-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924",,Q100705852,,,,634968-1,wfo-0000960320,5311411,,
-880b7f48-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910",,Q55781795,,,,634967-1,wfo-0000960321,7634819,,
+880b5ca2-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924","Schlechter, R. (1924). Contributions to South African Orchideology. Annals of the Transvaal Museum, 10(4), 233-248.
+
+
+",Q100705852,,,,634968-1,wfo-0000960320,5311411,,
+880b7f48-8fcd-11eb-924d-9cd76263cbd0,species,transvaalensis,Eulophia,,Rolfe,,1910,,"Bull. Misc. Inform. Kew 1910: 282 1910","New Orchids: Decade 36. (1910). Bulletin of Miscellaneous Information, 1910(8), 280. https://doi.org/10.2307/4111720
+
+
+",Q55781795,DOI:10.2307/4111720,,,634967-1,wfo-0000960321,7634819,,
 880b9dac-8fcd-11eb-924d-9cd76263cbd0,variety,thorncroftii,Eulophia,transvaalensis,Schltr.,,1924,,"Ann. Transvaal Mus. 10: 237 1924",,,,,,,wfo-0000960322,5312007,,
 880bbbb6-8fcd-11eb-924d-9cd76263cbd0,species,triceras,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 578 1915",,,,,,634969-1,wfo-0000960323,5311545,,
 880bd826-8fcd-11eb-924d-9cd76263cbd0,species,tricristata,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 218 1903",,,,,,634970-1,wfo-0000960324,5311990,,
 880c4928-8fcd-11eb-924d-9cd76263cbd0,species,trilamellata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 127 1919",,,,,,634971-1,wfo-0000960328,5311879,,
-880c6642-8fcd-11eb-924d-9cd76263cbd0,species,triloba,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 81 1917",,Q55782426,,,,634972-1,wfo-0000960329,5311395,,
+880c6642-8fcd-11eb-924d-9cd76263cbd0,species,triloba,Eulophia,,Rolfe,,1917,,"Bull. Misc. Inform. Kew 1917: 81 1917","New Orchids: Decade XLV. (1917). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1917(2), 80. https://doi.org/10.2307/4113400
+
+
+",Q55782426,DOI:10.2307/4113400,,,634972-1,wfo-0000960329,5311395,,
 880c8212-8fcd-11eb-924d-9cd76263cbd0,species,tristis,Eulophia,,"(L.f.) Spreng.",,1826,,"Syst. Veg. 3: 720 1826",,,,,,634973-1,wfo-0000960330,5312515,,
-880ca148-8fcd-11eb-924d-9cd76263cbd0,species,tuberculata,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 184 1889",,Q55760323,,,,634974-1,wfo-0000960331,5311761,,
+880ca148-8fcd-11eb-924d-9cd76263cbd0,species,tuberculata,Eulophia,,Bolus,,1889,,"J. Linn. Soc., Bot. 25: 184 1889","Bolus, H. (1889). Contributions to South-African Botany.- Part IV. (With a Revised List of published Species of Extra-tropical South-African Orchids). Transactions of the Linnean Society of London: Botany, 25(170), 156–210. https://doi.org/10.1111/j.1095-8339.1889.tb00795.x
+
+
+",Q55760323,DOI:10.1111/j.1095-8339.1889.tb00795.x,,,634974-1,wfo-0000960331,5311761,,
 880cbebc-8fcd-11eb-924d-9cd76263cbd0,species,tuberifera,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,634975-1,wfo-0000960332,5311344,,
 c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,"Bot. Jahrb. Syst. 28: 169 1900",,,,,,,wfo-0001088702,7472447,,
-880cdcd0-8fcd-11eb-924d-9cd76263cbd0,species,turkestanica,Eulophia,,"(Litv.) Schltr.",,1913,,"Repert. Spec. Nov. Regni Veg. 12: 374 1913",,Q55752861,,,,634976-1,wfo-0000960333,5311484,,
-880cf6de-8fcd-11eb-924d-9cd76263cbd0,species,ucbii,Eulophia,,"Malhotra & Balodi",,1984,,"Bull. Bot. Surv. India 26: 92 1984 publ. 1985",,Q101073683,,,,929052-1,wfo-0000960334,5312160,,
-880d138a-8fcd-11eb-924d-9cd76263cbd0,species,ugandae,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913",,Q55783828,,,,634977-1,wfo-0000960335,5323758,,
+880cdcd0-8fcd-11eb-924d-9cd76263cbd0,species,turkestanica,Eulophia,,"(Litv.) Schltr.",,1913,,"Repert. Spec. Nov. Regni Veg. 12: 374 1913","Schlechter, R. (1913). LXVI. Eulophia turcestanica (Litw.) Schltr., nov. comb. Feddes Repertorium Specierum Novarum Regni Vegetabilis, 12(22-24), 374. https://doi.org/10.1002/fedr.19130122209
+
+
+",Q55752861,DOI:10.1002/fedr.19130122209,,,634976-1,wfo-0000960333,5311484,,
+880cf6de-8fcd-11eb-924d-9cd76263cbd0,species,ucbii,Eulophia,,"Malhotra & Balodi",,1984,,"Bull. Bot. Surv. India 26: 92 1984 publ. 1985","Malhotra, C. L., & Balodi, B. (1984). A New Species of Eulophia R. Br. (orchidaceae) from Gori Valley. Bulletin of the Botanical Survey of India, 26(1-2), 92-94. https://doi.org/10.20324/nelumbo/v26/1984/74853
+
+
+",Q101073683,DOI:10.20324/nelumbo/v26/1984/74853,,,929052-1,wfo-0000960334,5312160,,
+880d138a-8fcd-11eb-924d-9cd76263cbd0,species,ugandae,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028
+
+
+",Q55783828,DOI:10.2307/4115028,,,634977-1,wfo-0000960335,5323758,,
 880d2fa0-8fcd-11eb-924d-9cd76263cbd0,species,ukingensis,Eulophia,,Schltr.,,1915,,"Bot. Jahrb. Syst. 53: 579 1915",,,,,,634978-1,wfo-0000960336,5311586,,
 880d48f0-8fcd-11eb-924d-9cd76263cbd0,species,undulata,Eulophia,,Rolfe,,1905,,"Gard. Chron. III, 38: 198 1905",,,,,,,wfo-0000960337,5311435,,
 880d81ee-8fcd-11eb-924d-9cd76263cbd0,species,ustulata,Eulophia,,"(Bolus) Bolus",,1888,,"Trans. S. African Philos. Soc. 5(1): 110 1888",,,,,,634980-1,wfo-0000960339,5312519,,
-880d9fbc-8fcd-11eb-924d-9cd76263cbd0,species,vaginata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 467 1885",,Q55760268,,,,634981-1,wfo-0000960340,5311391,,
-880dbcc2-8fcd-11eb-924d-9cd76263cbd0,species,vandervekeniana,Eulophia,,Geerinck,,1977,,"Bull. Jard. Bot. Natl. Belg. 47: 484 1977",,Q55776470,,,,634982-1,wfo-0000960341,5307900,,
+880d9fbc-8fcd-11eb-924d-9cd76263cbd0,species,vaginata,Eulophia,,Ridl.,,1885,,"J. Linn. Soc., Bot. 21: 467 1885","Ridley, H. N. (1885). The Orchids of Madagascar. Transactions of the Linnean Society of London. Botany, 21(137), 456–522. https://doi.org/10.1111/j.1095-8339.1885.tb00573.x
+
+
+",Q55760268,DOI:10.1111/j.1095-8339.1885.tb00573.x,,,634981-1,wfo-0000960340,5311391,,
+880dbcc2-8fcd-11eb-924d-9cd76263cbd0,species,vandervekeniana,Eulophia,,Geerinck,,1977,,"Bull. Jard. Bot. Natl. Belg. 47: 484 1977","Geerinck, D. (1977). Deux nouvelles especes d’ Orchidaceae pour le Rwanda et le Burundi. Bulletin Van De Nationale Plantentuin Van België, 47(3/4), 484. https://doi.org/10.2307/3667915
+
+
+",Q55776470,DOI:10.2307/3667915,,,634982-1,wfo-0000960341,5307900,,
 880dd64e-8fcd-11eb-924d-9cd76263cbd0,species,vanoverberghii,Eulophia,,Ames,,1912,,"Philipp. J. Sci., C 7: 13 1912",,,,,,634983-1,wfo-0000960342,5311851,,
 880df03e-8fcd-11eb-924d-9cd76263cbd0,species,variopicta,Eulophia,,Chiov.,,1911,,"Ann. Bot. (Rome) 9: 135 1911",,,,,,634984-1,wfo-0000960343,5312032,,
 880e0cea-8fcd-11eb-924d-9cd76263cbd0,species,venosa,Eulophia,,"(F.Muell.) Rchb.f. ex Benth.",,1873,,"Fl. Austral. 6: 300 1873",,,,,,634985-1,wfo-0000960344,5312085,,
@@ -677,7 +1178,10 @@ c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,
 880e4dcc-8fcd-11eb-924d-9cd76263cbd0,species,venusta,Eulophia,,Schltr.,,1919,,"Repert. Spec. Nov. Regni Veg. Beih. 4: 72 1919",,,,,,634987-1,wfo-0000960346,5312033,,
 880e6b86-8fcd-11eb-924d-9cd76263cbd0,species,vera,Eulophia,,Royle,,1839,,"Ill. Bot. Himal. Mts. 366 1839",,,,,,,wfo-0000960347,5311472,,
 880e9fa2-8fcd-11eb-924d-9cd76263cbd0,species,vermiculata,Eulophia,,"De Wild.",,1919,,"Bull. Jard. Bot. État 6: 107 1919",,,,,,634989-1,wfo-0000960348,5311325,,
-880ef0ba-8fcd-11eb-924d-9cd76263cbd0,species,verrucosa,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975",,Q105743545,,,,634990-1,wfo-0000960350,5311763,,
+880ef0ba-8fcd-11eb-924d-9cd76263cbd0,species,verrucosa,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,634990-1,wfo-0000960350,5311763,,
 880f1a18-8fcd-11eb-924d-9cd76263cbd0,species,versicolor,Eulophia,,"Frapp. ex Cordem.",,1895,,"Fl. Réunion 221 1895",,,,,,634991-1,wfo-0000960351,5311878,,
 880f3d2c-8fcd-11eb-924d-9cd76263cbd0,species,versteegii,Eulophia,,J.J.Sm.,,1908,,"Bull. Dép. Agric. Indes Néerl. 19: 24 1908",,,,,,634992-1,wfo-0000960352,5311856,,
 880f596a-8fcd-11eb-924d-9cd76263cbd0,species,violacea,Eulophia,,Rchb.f.,,1847,,"Linnaea 20: 683 1847",,,,,,634993-1,wfo-0000960353,5311383,,
@@ -686,24 +1190,45 @@ c3e20db6-8fcd-11eb-924d-9cd76263cbd0,species,tubifera,Eulophia,,Kraenzl.,,1900,,
 880f8eee-8fcd-11eb-924d-9cd76263cbd0,species,virens,Eulophia,,"Stocks ex Lindl.",,1858,,"J. Proc. Linn. Soc., Bot. 3: 25 1858",,,,,,634995-1,wfo-0000960355,7901487,,
 880fc54e-8fcd-11eb-924d-9cd76263cbd0,species,viridiflora,Eulophia,,Steud.,,1840,,"Nomencl. Bot. ed. 2, 1: 605 1840",,,,,,,wfo-0000960357,5311556,,
 880fdf16-8fcd-11eb-924d-9cd76263cbd0,species,virilis,Eulophia,,Lindl.,,1862,,"J. Proc. Linn. Soc., Bot. 6: 132 1862",,,,,,635000-1,wfo-0000960358,5308350,,
-880ffa0a-8fcd-11eb-924d-9cd76263cbd0,species,vleminckxiana,Eulophia,,"Geerinck & Schaijes",,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 188 1990",,Q55776633,,,,940399-1,wfo-0000960359,5311403,,
-881031dc-8fcd-11eb-924d-9cd76263cbd0,species,volkensii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975",,Q105743545,,,,635001-1,wfo-0000960361,5311520,,
-88105004-8fcd-11eb-924d-9cd76263cbd0,species,wakefieldii,Eulophia,,"(Rchb.f. & S.Moore) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 500 1939",,Q55782484,,db703680-8fcb-11eb-924d-9cd76263cbd0,,635002-1,wfo-0000960362,5311508,,
+880ffa0a-8fcd-11eb-924d-9cd76263cbd0,species,vleminckxiana,Eulophia,,"Geerinck & Schaijes",,1990,,"Bull. Jard. Bot. Natl. Belg. 60: 188 1990","Geerinck, D. (1990). Notes taxonomiques sur des Orchidacees d’Afrique centrale. X. Bulletin Du Jardin Botanique National De Belgique, 60(1/2), 181. https://doi.org/10.2307/3668340
+
+
+",Q55776633,DOI:10.2307/3668340,,,940399-1,wfo-0000960359,5311403,,
+881031dc-8fcd-11eb-924d-9cd76263cbd0,species,volkensii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,635001-1,wfo-0000960361,5311520,,
+88105004-8fcd-11eb-924d-9cd76263cbd0,species,wakefieldii,Eulophia,,"(Rchb.f. & S.Moore) Summerh.",,1939,,"Bull. Misc. Inform. Kew 1939: 500 1939","Summerhayes, V. S. (1939). African Orchids: XI. Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1939(9), 489. https://doi.org/10.2307/4113454
+
+
+",Q55782484,DOI:10.2307/4113454,db703680-8fcb-11eb-924d-9cd76263cbd0,,635002-1,wfo-0000960362,5311508,,
 88106d32-8fcd-11eb-924d-9cd76263cbd0,species,walleri,Eulophia,,"(Rchb.f.) Kraenzl.",,1895,,"Pflanzenw. Ost-Afrikas C: 157 1895",,,,,,,wfo-0000960363,5311429,,
 88109406-8fcd-11eb-924d-9cd76263cbd0,species,warburgiana,Eulophia,,Kraenzl.,,1893,,"Xenia Orchid. 3: 115 1893",,,,,,,wfo-0000960364,5543230,,
 8810b3f0-8fcd-11eb-924d-9cd76263cbd0,species,warburgii,Eulophia,,Schltr.,,1903,,"Kunene-Sambesi Exped. 214 1903",,,,,,635005-1,wfo-0000960365,5311340,,
 8810cde0-8fcd-11eb-924d-9cd76263cbd0,species,warneckeana,Eulophia,,Kraenzl.,,1902,,"Bot. Jahrb. Syst. 33: 67 1902",,,,,,635006-1,wfo-0000960366,5311443,,
-8810ea50-8fcd-11eb-924d-9cd76263cbd0,species,watkinsonii,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913",,Q55783828,,,,635007-1,wfo-0000960367,5311410,,
+8810ea50-8fcd-11eb-924d-9cd76263cbd0,species,watkinsonii,Eulophia,,Rolfe,,1913,,"Bull. Misc. Inform. Kew 1913: 339 1913","New Orchids; Decade 41. (1913). Bulletin of Miscellaneous Information, Royal Gardens, Kew, 1913(9), 338. https://doi.org/10.2307/4115028
+
+
+",Q55783828,DOI:10.2307/4115028,,,635007-1,wfo-0000960367,5311410,,
 881120f6-8fcd-11eb-924d-9cd76263cbd0,species,welwitschii,Eulophia,,"(Rchb.f.) Rolfe",,1889,,"Bol. Soc. Brot. 7: 236 1889",,,,,,635008-1,wfo-0000960369,5311917,,
 881106f2-8fcd-11eb-924d-9cd76263cbd0,species,welwitschii,Eulophia,,Hook.f.,,,,"Bot. Mag. 119: t. 7330 1893",,,,,,635009-1,wfo-0000960368,7965576,,
 309c373e-8fcd-11eb-924d-9cd76263cbd0,subspecies,aurantiaca,Eulophia,welwitschii,"(Rolfe) Geerinck",,2004,,"Taxonomania 14: 12 2004",,,,87c2ca1e-8fcd-11eb-924d-9cd76263cbd0,,77065537-1,wfo-0000795140,5311467,,
 309c53a4-8fcd-11eb-924d-9cd76263cbd0,subspecies,carsonii,Eulophia,welwitschii,"(Rolfe) Geerinck",,2005,,"Taxonomania 16: 9 2005",,,,,,77069398-1,wfo-0000795141,5311316,,
 88113a1e-8fcd-11eb-924d-9cd76263cbd0,species,wendlandiana,Eulophia,,Kraenzl.,,1897,,"Gard. Chron. III, 22: 262 1897",,,,,,,wfo-0000960370,5312048,,
-881172a4-8fcd-11eb-924d-9cd76263cbd0,species,williamsonii,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 166 1977",,Q43230546,,,,635011-1,wfo-0000960372,5311686,,
-88118bfe-8fcd-11eb-924d-9cd76263cbd0,species,wilsonii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975",,Q105743545,,,,635012-1,wfo-0000960373,5311529,,
+881172a4-8fcd-11eb-924d-9cd76263cbd0,species,williamsonii,Eulophia,,P.J.Cribb,,1977,,"Kew Bull. 32: 166 1977","Cribb, P. J. (1977). New Orchids from South Central Africa. Kew Bulletin, 32(1), 137–187. https://doi.org/10.2307/4117264
+
+
+",Q43230546,DOI:10.2307/4117264,,,635011-1,wfo-0000960372,5311686,,
+88118bfe-8fcd-11eb-924d-9cd76263cbd0,species,wilsonii,Eulophia,,"(Rolfe) Butzin",,1975,,"Willdenowia 7: 590 1975","Butzin, F. (1975). Neue Namen und neue Kombinationen in der Orchideengattung Eulophia (New Names and New Combinations in the Orchid Genus Eulophia). Willdenowia, 7(3), 587-590.
+
+
+",Q105743545,,,,635012-1,wfo-0000960373,5311529,,
 8811a7ce-8fcd-11eb-924d-9cd76263cbd0,species,woodfordii,Eulophia,,"(Sims) Rolfe",,1897,,"Fl. Trop. Afr. 7: 68 1897",,,,7d3bbae2-8fcd-11eb-924d-9cd76263cbd0,,635013-1,wfo-0000960374,5311799,,
 8811c83a-8fcd-11eb-924d-9cd76263cbd0,species,woodii,Eulophia,,Schltr.,,1895,,"Bot. Jahrb. Syst. 20(50): 5 1895",,,,,,635014-1,wfo-0000960375,5311918,,
-8811e5fe-8fcd-11eb-924d-9cd76263cbd0,species,yunnanensis,Eulophia,,Rolfe,,1903,,"J. Linn. Soc., Bot. 36: 29 1903",,Q55760426,,,,635015-1,wfo-0000960376,5305652,,
+8811e5fe-8fcd-11eb-924d-9cd76263cbd0,species,yunnanensis,Eulophia,,Rolfe,,1903,,"J. Linn. Soc., Bot. 36: 29 1903","Forbes, F. B., & Hemsley, W. B. (1903). An Enumeration of all the Plants known from China Proper, Formosa, Hainan, Corea, the Luchu Archipelago, and the Island of Hongkong, together with their Distribution and Synonymy. Part-XIV. Transactions of the Linnean Society of London: Botany, 36(249), 1–72. https://doi.org/10.1111/j.1095-8339.1903.tb02550.x
+
+
+",Q55760426,DOI:10.1111/j.1095-8339.1903.tb02550.x,,,635015-1,wfo-0000960376,5305652,,
 88120246-8fcd-11eb-924d-9cd76263cbd0,species,yushuiana,Eulophia,,S.Y.Hu,,1972,,"Chung Chi J. 11: 19 1972",,,,,,635016-1,wfo-0000960377,5311695,,
 88121e5c-8fcd-11eb-924d-9cd76263cbd0,species,zeyheri,Eulophia,,Hook.f.,,,,"Bot. Mag. 119: t. 7330 1893",,,,,,635018-1,wfo-0000960378,5311921,,
 88123810-8fcd-11eb-924d-9cd76263cbd0,species,zeyheriana,Eulophia,,Sond.,,1846,,"Linnaea 19: 73 1846",,,,,,635019-1,wfo-0000960379,5311748,,


### PR DESCRIPTION
@rogerhyam  As a test I've added citation strings for publications in Wikidata, and the DOI for the publication (if one exists). The citations are in APA format. The DOIs have prefix "DOI:" so that it's obvious that they are DOIs. Some publications don't have DOIs may may well have other identifiers (e.g., Handles, JSTOR, BioStor, etc.).